### PR TITLE
Video streaming node + minor patches

### DIFF
--- a/docker/truck-jetson.dockerfile
+++ b/docker/truck-jetson.dockerfile
@@ -369,6 +369,11 @@ RUN printf "export CC='${CC}'\n" >> /root/.bashrc \
     && printf "export RCUTILS_CONSOLE_OUTPUT_FORMAT='[{severity}:{time}] {message}'\n" >> /root/.bashrc \
     && ln -sf /usr/bin/clang-format-${CLANG_VERSION} /usr/bin/clang-format
 
+### VIDEO STREAMING SERVER (MEDIAMTX)
+
+ARG MEDIAMTX_VERSION="0.22.2"
+RUN wget -qO - https://github.com/aler9/mediamtx/releases/download/v${MEDIAMTX_VERSION}/mediamtx_v${MEDIAMTX_VERSION}_linux_arm64v8.tar.gz | tar -xz -C /usr/bin mediamtx 
+
 ### SETUP ENTRYPOINT
 
 COPY /entrypoint.bash /entrypoint.bash

--- a/packages/control_proxy/src/control_proxy_node.cpp
+++ b/packages/control_proxy/src/control_proxy_node.cpp
@@ -53,8 +53,7 @@ ControlProxyNode::ControlProxyNode()
         loadControlMap(
             this->get_logger(),
             Node::declare_parameter<std::string>("control_config")))
-    , frame_id_("base")
-    , mode_(Mode::Auto) {
+    , frame_id_("base") {
     RCLCPP_INFO(
         this->get_logger(),
         "max velocity: %f, min velocity: %f",

--- a/packages/control_proxy/src/control_proxy_node.cpp
+++ b/packages/control_proxy/src/control_proxy_node.cpp
@@ -210,8 +210,6 @@ void ControlProxyNode::watchdog() {
         return std::chrono::nanoseconds(duration_ns) > timeout;
     };
 
-    return;
-
     if (mode_ == Mode::Off) {
         publishStop();
         return;

--- a/packages/model/config/model.yaml
+++ b/packages/model/config/model.yaml
@@ -12,8 +12,8 @@ wheel_base:
 limits:
   steering: { inner: 40.0, outer: 40.0 }   # deg
   max_abs_curvature: 2.0                   # 1/m
-  velocity: { min: -0.5, max: 0.5 }        # m/s
-  acceleration: { min: -1.0, max: +1.0 }   # m/s^2
+  velocity: { min: -0.3, max: 0.3 }        # m/s
+  acceleration: { min: -0.6, max: +0.6 }   # m/s^2
 
 wheel_radius: 0.0525 # m
 # Motor to differential ratio. See docs/gearbox.md for more info.

--- a/packages/model/config/model.yaml
+++ b/packages/model/config/model.yaml
@@ -12,8 +12,8 @@ wheel_base:
 limits:
   steering: { inner: 40.0, outer: 40.0 }   # deg
   max_abs_curvature: 2.0                   # 1/m
-  velocity: { min: -0.3, max: 0.3 }        # m/s
-  acceleration: { min: -0.6, max: +0.6 }   # m/s^2
+  velocity: { min: -0.5, max: 0.5 }        # m/s
+  acceleration: { min: -1.0, max: +1.0 }   # m/s^2
 
 wheel_radius: 0.0525 # m
 # Motor to differential ratio. See docs/gearbox.md for more info.

--- a/packages/model/src/model.cpp
+++ b/packages/model/src/model.cpp
@@ -63,7 +63,7 @@ WheelVelocity Model::rearTwistToWheelVelocity(Twist twist) const {
 }
 
 double Model::linearVelocityToMotorRPS(double velocity) const {
-    return velocity / params_.wheel_radius / M_PI / params_.gear_ratio;
+    return velocity / params_.wheel_radius / M_PI / params_.gear_ratio / 2;
 }
 
 double Model::gearRatio() const { return params_.gear_ratio; }

--- a/packages/perf/launch/perf_stat.yaml
+++ b/packages/perf/launch/perf_stat.yaml
@@ -4,5 +4,3 @@ launch:
     exec: "perf_stat_node"
     name: "perf_stat_node"
     output: "log"
-- include:
-    file: $(find-pkg-share truck)/launch/rosbridge.yaml

--- a/packages/truck/launch/truck.yaml
+++ b/packages/truck/launch/truck.yaml
@@ -16,3 +16,9 @@ launch:
     - {name: "simulation", value: "false"}
     - {name: "qos", value: "0"}
     - {name: "control_name", value: "$(var control_name)"}
+
+- include:
+    file: $(find-pkg-share perf)/launch/perf_stat.yaml
+
+- include:
+    file: $(find-pkg-share video_streaming)/launch/video_streaming.yaml

--- a/packages/truck/package.xml
+++ b/packages/truck/package.xml
@@ -20,6 +20,8 @@
   <depend>truck_gazebo</depend>
   <depend>truck_gazebo_plugins</depend>
   <depend>visualization</depend>
+  <depend>perf</depend>
+  <depend>video_streaming</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/packages/video_streaming/CMakeLists.txt
+++ b/packages/video_streaming/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.8)
+project(video_streaming)
+
+find_package(ament_cmake REQUIRED)
+
+install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
+install(FILES mediamtx.yaml DESTINATION share/${PROJECT_NAME})
+
+ament_package()

--- a/packages/video_streaming/launch/video_streaming.yaml
+++ b/packages/video_streaming/launch/video_streaming.yaml
@@ -1,0 +1,6 @@
+launch:
+- executable:
+    name: "video_streaming"
+    cmd: "mediamtx $(find-pkg-share video_streaming)/mediamtx.yaml"
+    output: "screen"
+    shell: True

--- a/packages/video_streaming/mediamtx.yaml
+++ b/packages/video_streaming/mediamtx.yaml
@@ -1,0 +1,19 @@
+logLevel: info
+logDestinations: [stdout]
+
+rtmpDisable: yes
+hlsDisable: yes
+rtspAddress: :8554
+webrtcAddress: :8889
+
+paths:
+  cam:
+    source: publisher
+    runOnDemandRestart: yes
+    runOnDemandCloseAfter: 10s
+    runOnDemand: >
+      gst-launch-1.0
+      nvv4l2camerasrc device=/dev/video4
+      ! 'video/x-raw(memory:NVMM), format=YUY2, width=640, height=480, framerate=30/1'
+      ! nvvidconv ! nvv4l2vp9enc bitrate=400000 maxperf-enable=true
+      ! rtspclientsink location=rtsp://localhost:$RTSP_PORT/$RTSP_PATH

--- a/packages/video_streaming/package.xml
+++ b/packages/video_streaming/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>video_streaming</name>
+  <version>0.1.0</version>
+  <description>Live video streaming server based on MediaMTX + Nvidia Accelerated GStreamer</description>
+  <maintainer email="andbondstyle@gmail.com">AndBondStyle</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/packages/waypoint_follower/launch/waypoint_follower.yaml
+++ b/packages/waypoint_follower/launch/waypoint_follower.yaml
@@ -16,5 +16,5 @@ launch:
     - {name: "period", value: 0.1}
     - {name: "resolution", value: 0.02}
     - {name: "check_in_distance", value: 0.30}
-    - {name: "safety_margin", value: 0.15}
-    - {name: "distance_before_obstacle", value: 1.5}
+    - {name: "safety_margin", value: 0.05}
+    - {name: "distance_before_obstacle", value: 1.0}

--- a/packages/waypoint_follower/launch/waypoint_follower.yaml
+++ b/packages/waypoint_follower/launch/waypoint_follower.yaml
@@ -16,5 +16,5 @@ launch:
     - {name: "period", value: 0.1}
     - {name: "resolution", value: 0.02}
     - {name: "check_in_distance", value: 0.30}
-    - {name: "safety_margin", value: 0.05}
-    - {name: "distance_before_obstacle", value: 1.0}
+    - {name: "safety_margin", value: 0.15}
+    - {name: "distance_before_obstacle", value: 1.5}

--- a/scripts/rosenv.sh
+++ b/scripts/rosenv.sh
@@ -1,3 +1,3 @@
 echo "Loading ROS environment variables..."
-source /opt/ros/galactic/setup.sh
+source /opt/ros/$ROS_DISTRO/setup.sh
 source packages/install/setup.sh


### PR DESCRIPTION
- Add `video_streaming` node
- Change encoder to VP9, as it's looks like to be more stable with WebRTC
- Added extra dependencies to dockerfile (mediamtx binary)
- Disable starting in AUTO mode
- Fix gear ratio calculation in model lib (i forgor :skull:)
- Random fixes in launch files