### PR TITLE
[WIP] Public DVC remote

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,6 +1,4 @@
 [core]
-    remote = main
-['remote "main"']
-    url = s3://the-lab-bucket/dvc
-    endpointurl = https://storage.yandexcloud.net
-    region = ru-central1
+    remote = public
+['remote "public"']
+    url = https://the-lab-storage.storage.yandexcloud.net/

--- a/.dvc/config
+++ b/.dvc/config
@@ -1,4 +1,4 @@
 [core]
     remote = public
 ['remote "public"']
-    url = https://the-lab-storage.storage.yandexcloud.net/
+    url = https://the-lab-bucket.storage.yandexcloud.net/dvc/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3"
 services:
   truck:
     container_name: "${CONTAINER_NAME:-truck-${USER}}"
-    image: registry.robotics-lab.ru/truck:0.8.0
+    image: registry.robotics-lab.ru/truck:0.8.1
     privileged: true
     runtime: "${DOCKER_RUNTIME:-runc}"
     build:
@@ -11,7 +11,7 @@ services:
       context: .
       tags:
         - "registry.robotics-lab.ru/truck:latest"
-        - "registry.robotics-lab.ru/truck:0.8.0"
+        - "registry.robotics-lab.ru/truck:0.8.1"
       x-bake:
         platforms: [linux/arm64/v8, linux/amd64]
         cache-to: "type=registry,ref=registry.robotics-lab.ru/truck:cache,mode=max"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ odrive==0.6.1.post0
 pybind11==2.10.0
 pyomo==6.1.2
 pyserial==3.5
-dvc==3.31.2
+dvc[s3]==3.31.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-
 -i https://pypi.org/simple
 matplotlib==3.5.1
 msgpacketizer==0.2.0
@@ -8,4 +7,4 @@ odrive==0.6.1.post0
 pybind11==2.10.0
 pyomo==6.1.2
 pyserial==3.5
- 
+dvc==3.31.2


### PR DESCRIPTION
Added a public DVC remote with anonymous **pull** access (via https). To acquire **push** permissions, you (as a contributor) will still need to manually create a private remote as [described here](https://github.com/robotics-laboratory/truck/blob/master/packages/truck_gazebo/README.md). This is done only once, and the S3 access tokens will be stored in `.dvc/config.local`.