### PR TITLE
perf: switch collision from OpenCV to fastgrid

### DIFF
--- a/packages/collision/CMakeLists.txt
+++ b/packages/collision/CMakeLists.txt
@@ -6,7 +6,9 @@ add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(common REQUIRED)
+find_package(fastgrid REQUIRED)
 find_package(geom REQUIRED)
+find_package(map REQUIRED)
 find_package(model REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(OpenCV REQUIRED)
@@ -20,7 +22,9 @@ add_library(
 ament_target_dependencies(
     collision
     common
+    fastgrid
     geom
+    map
     model
     nav_msgs
     OpenCV
@@ -35,7 +39,9 @@ ament_export_targets(collision HAS_LIBRARY_TARGET)
 
 ament_export_dependencies(
     common
+    fastgrid
     geom
+    map
     model
     nav_msgs
     OpenCV
@@ -50,5 +56,12 @@ install(
 )
 
 install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+    find_package(ament_cmake_clang_format REQUIRED)
+    ament_clang_format(CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-format")
+
+    add_subdirectory("test")
+endif()
 
 ament_package()

--- a/packages/collision/include/collision/collision_checker.h
+++ b/packages/collision/include/collision/collision_checker.h
@@ -2,6 +2,8 @@
 
 #include "collision/map.h"
 
+#include "fastgrid/interpolation.h"
+
 #include "geom/pose.h"
 #include "geom/transform.h"
 #include "geom/vector.h"
@@ -20,7 +22,7 @@ class StaticCollisionChecker {
     StaticCollisionChecker(const model::Shape& shape);
 
     bool initialized() const;
-    void reset(Map distance_transform);
+    void reset(const fastgrid::F32Grid& distance_map);
 
     double distance(const geom::Pose& ego_pose) const;
     double distance(const geom::Vec2& point) const;
@@ -29,11 +31,8 @@ class StaticCollisionChecker {
     model::Shape shape_;
 
     struct State {
-        Map distance_transform;
-        geom::Transform tf;
-    };
-
-    std::optional<State> state_ = std::nullopt;
+        std::optional<fastgrid::Bilinear<float>> distance_transform = std::nullopt;
+    } state_;
 };
 
 }  // namespace truck::collision

--- a/packages/collision/package.xml
+++ b/packages/collision/package.xml
@@ -9,7 +9,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>common</depend>
+  <depend>fastgrid</depend>
   <depend>geom</depend>
+  <depend>map</depend>
   <depend>model</depend>
   <depend>nav_msgs</depend>
   <depend>OpenCV</depend>

--- a/packages/collision/test/CMakeLists.txt
+++ b/packages/collision/test/CMakeLists.txt
@@ -1,0 +1,10 @@
+find_package(ament_cmake_gtest REQUIRED)
+
+ament_add_gtest(${PROJECT_NAME}_tests main.cpp)
+target_link_libraries(${PROJECT_NAME}_tests ${PROJECT_NAME})
+set_tests_properties(${Tests} PROPERTIES TIMEOUT 10)
+
+target_include_directories(${PROJECT_NAME}_tests PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")

--- a/packages/collision/test/main.cpp
+++ b/packages/collision/test/main.cpp
@@ -1,0 +1,200 @@
+#include <gtest/gtest.h>
+
+#include "fastgrid/distance_transform.h"
+
+#include "geom/test/equal_assert.h"
+#include "geom/msg.h"
+
+#include "collision/map.h"
+
+using namespace truck::geom;
+using namespace truck::fastgrid;
+using namespace truck::collision;
+using namespace truck::map;
+
+TEST(CollisionMap, BitMap) {
+    constexpr double eps = 1e-7;
+
+    auto collision_map = CollisionMap();
+
+    {
+        auto bit_map = collision_map.GetBitMap();
+        EXPECT_EQ(bit_map.size.width, 0);
+        EXPECT_EQ(bit_map.size.height, 0);
+        EXPECT_DOUBLE_EQ(bit_map.resolution, 0.0);
+        EXPECT_EQ(bit_map.origin, std::nullopt);
+    }
+
+    {
+        nav_msgs::msg::OccupancyGrid grid;
+        grid.info.resolution = 0.5;
+        grid.info.width = 10;
+        grid.info.height = 10;
+        grid.info.origin = msg::toPose(Pose(Vec2(0, 0), AngleVec2::fromVector(1, 0)));
+
+        std::vector<int8_t> data(100, 1);
+        grid.data = data;
+
+        collision_map.SetOccupancyGrid(std::make_shared<nav_msgs::msg::OccupancyGrid>(grid));
+
+        auto bit_map = collision_map.GetBitMap();
+
+        EXPECT_EQ(bit_map.size.width, 10);
+        EXPECT_EQ(bit_map.size.height, 10);
+        EXPECT_DOUBLE_EQ(bit_map.resolution, 0.5);
+        ASSERT_GEOM_EQUAL(bit_map.origin->pose, Pose(Vec2(0, 0), AngleVec2::fromVector(1, 0)));
+        EXPECT_EQ(static_cast<int>(bit_map[0][0]), 0);
+    }
+
+    {
+        nav_msgs::msg::OccupancyGrid grid;
+        grid.info.resolution = 1.5;
+        grid.info.width = 3;
+        grid.info.height = 3;
+        grid.info.origin = msg::toPose(Pose(Vec2(1, 1), AngleVec2::fromVector(0, 1)));
+
+        std::vector<int8_t> data(9, 0);
+        grid.data = data;
+
+        collision_map.SetOccupancyGrid(std::make_shared<nav_msgs::msg::OccupancyGrid>(grid));
+
+        auto bit_map = collision_map.GetBitMap();
+
+        EXPECT_EQ(bit_map.size.width, 3);
+        EXPECT_EQ(bit_map.size.height, 3);
+        EXPECT_DOUBLE_EQ(bit_map.resolution, 1.5);
+        ASSERT_GEOM_EQUAL(bit_map.origin->pose, Pose(Vec2(1, 1), AngleVec2::fromVector(0, 1)));
+        EXPECT_EQ(static_cast<int>(bit_map[0][0]), 1);
+    }
+
+    {
+        nav_msgs::msg::OccupancyGrid grid;
+        grid.info.resolution = 1.0;
+        grid.info.width = 3;
+        grid.info.height = 3;
+        grid.info.origin = msg::toPose(Pose(Vec2(0, 0), AngleVec2::fromVector(1, 0)));
+
+        std::vector<int8_t> data(9, 0);
+        grid.data = data;
+
+        collision_map.SetOccupancyGrid(std::make_shared<nav_msgs::msg::OccupancyGrid>(grid));
+
+        ComplexPolygon polygon;
+        polygon.outer = {Vec2(1, 1), Vec2(2 - eps, 1), Vec2(2 - eps, 2 - eps), Vec2(1, 2 - eps)};
+        auto map = Map({polygon});
+
+        collision_map.SetMap(std::make_shared<Map>(map));
+
+        auto bit_map = collision_map.GetBitMap();
+
+        EXPECT_EQ(static_cast<int>(bit_map[0][0]), 0);
+        EXPECT_EQ(static_cast<int>(bit_map[0][1]), 0);
+        EXPECT_EQ(static_cast<int>(bit_map[0][2]), 0);
+        EXPECT_EQ(static_cast<int>(bit_map[1][0]), 0);
+        EXPECT_EQ(static_cast<int>(bit_map[1][1]), 1);
+        EXPECT_EQ(static_cast<int>(bit_map[1][2]), 0);
+        EXPECT_EQ(static_cast<int>(bit_map[2][0]), 0);
+        EXPECT_EQ(static_cast<int>(bit_map[2][1]), 0);
+        EXPECT_EQ(static_cast<int>(bit_map[2][2]), 0);
+    }
+
+    {
+        nav_msgs::msg::OccupancyGrid grid;
+        grid.info.resolution = 1.0;
+        grid.info.width = 3;
+        grid.info.height = 3;
+        grid.info.origin = msg::toPose(Pose(Vec2(1, 1), AngleVec2::fromVector(1, 0)));
+
+        std::vector<int8_t> data(9, 0);
+        grid.data = data;
+
+        collision_map.SetOccupancyGrid(std::make_shared<nav_msgs::msg::OccupancyGrid>(grid));
+
+        ComplexPolygon polygon;
+        polygon.outer = {Vec2(2, 2), Vec2(3, 2), Vec2(3, 3), Vec2(2, 3)};
+        auto map = Map({polygon});
+
+        collision_map.SetMap(std::make_shared<Map>(map));
+
+        auto bit_map = collision_map.GetBitMap();
+
+        EXPECT_EQ(static_cast<int>(bit_map[0][0]), 0);
+        EXPECT_EQ(static_cast<int>(bit_map[0][1]), 0);
+        EXPECT_EQ(static_cast<int>(bit_map[0][2]), 0);
+        EXPECT_EQ(static_cast<int>(bit_map[1][0]), 0);
+        EXPECT_EQ(static_cast<int>(bit_map[1][1]), 1);
+        EXPECT_EQ(static_cast<int>(bit_map[1][2]), 1);
+        EXPECT_EQ(static_cast<int>(bit_map[2][0]), 0);
+        EXPECT_EQ(static_cast<int>(bit_map[2][1]), 1);
+        EXPECT_EQ(static_cast<int>(bit_map[2][2]), 1);
+    }
+
+    {
+        nav_msgs::msg::OccupancyGrid grid;
+        grid.info.resolution = 1.0;
+        grid.info.width = 3;
+        grid.info.height = 3;
+        grid.info.origin = msg::toPose(Pose(Vec2(0, 0), AngleVec2::fromVector(1, 0)));
+
+        std::vector<int8_t> data(9, 0);
+        grid.data = data;
+
+        collision_map.SetOccupancyGrid(std::make_shared<nav_msgs::msg::OccupancyGrid>(grid));
+
+        ComplexPolygon polygon;
+        polygon.inners.push_back(
+            {Vec2(0, 0), Vec2(0, 1 - eps), Vec2(1 - eps, 1 - eps), Vec2(1 - eps, 0)});
+        polygon.inners.push_back(
+            {Vec2(1, 1), Vec2(1, 2 - eps), Vec2(2 - eps, 2 - eps), Vec2(2 - eps, 1)});
+
+        auto map = Map({polygon});
+
+        collision_map.SetMap(std::make_shared<Map>(map));
+
+        auto bit_map = collision_map.GetBitMap();
+
+        EXPECT_EQ(static_cast<int>(bit_map[0][0]), 0);
+        EXPECT_EQ(static_cast<int>(bit_map[0][1]), 1);
+        EXPECT_EQ(static_cast<int>(bit_map[0][2]), 1);
+        EXPECT_EQ(static_cast<int>(bit_map[1][0]), 1);
+        EXPECT_EQ(static_cast<int>(bit_map[1][1]), 0);
+        EXPECT_EQ(static_cast<int>(bit_map[1][2]), 1);
+        EXPECT_EQ(static_cast<int>(bit_map[2][0]), 1);
+        EXPECT_EQ(static_cast<int>(bit_map[2][1]), 1);
+        EXPECT_EQ(static_cast<int>(bit_map[2][2]), 1);
+    }
+}
+
+TEST(CollisionMap, DistanceMap) {
+    constexpr double eps = 1e-7;
+
+    auto collision_map = CollisionMap();
+
+    nav_msgs::msg::OccupancyGrid grid;
+    grid.info.resolution = 1.0;
+    grid.info.width = 3;
+    grid.info.height = 3;
+    grid.info.origin = msg::toPose(Pose(Vec2(0, 0), AngleVec2::fromVector(1, 0)));
+
+    std::vector<int8_t> data(9, 0);
+    data[0] = 1;
+    grid.data = data;
+
+    collision_map.SetOccupancyGrid(std::make_shared<nav_msgs::msg::OccupancyGrid>(grid));
+
+    ComplexPolygon polygon;
+    polygon.inners.push_back(
+        {Vec2(2, 2), Vec2(2, 3 - eps), Vec2(3 - eps, 3 - eps), Vec2(3 - eps, 2)});
+
+    auto map = Map({polygon});
+
+    collision_map.SetMap(std::make_shared<Map>(map));
+
+    auto distance_map = collision_map.GetDistanceMap();
+
+    auto occupancy_grid = makeGrid<uint8_t>(
+        Size{.width = 3, .height = 3}, 1.0, Pose(Vec2(0, 0), AngleVec2::fromVector(1, 0)));
+    auto distance_transform = distanceTransformApprox3(occupancy_grid.grid);
+
+    equal(distance_map, *distance_transform, eps);
+}

--- a/packages/fastgrid/include/fastgrid/interpolation.h
+++ b/packages/fastgrid/include/fastgrid/interpolation.h
@@ -36,8 +36,6 @@ struct Bilinear {
         const int x = static_cast<int>(point.x / domain.resolution);
         const int y = static_cast<int>(point.y / domain.resolution);
 
-        std::cerr << "x: " << x << " y: " << y << std::endl;
-
         const int index = y * domain.size.width + x;
 
         const double topLetf = grid.data[index];

--- a/packages/fastgrid/src/distance_transform.cpp
+++ b/packages/fastgrid/src/distance_transform.cpp
@@ -98,7 +98,7 @@ ALWAYS_INLINE void distanceTransformApprox(
     VERIFY(out.size == input.size);
 
     const auto scale = static_cast<float>(input.resolution) / step.hv;
-    const auto default_value = step.dg * input.size.max() / 6;
+    const auto default_value = step.dg * input.size.max();
 
     // fill top and bottom rows
     for (int i = 0; i < border; ++i) {

--- a/packages/geom/include/geom/line.h
+++ b/packages/geom/include/geom/line.h
@@ -3,6 +3,8 @@
 #include "geom/common.h"
 #include "geom/vector.h"
 
+#include <optional>
+
 namespace truck::geom {
 
 // ax + by + c = 0
@@ -30,6 +32,8 @@ struct Line {
 };
 
 bool equal(const Line& l1, const Line& l2, double eps) noexcept;
+
+std::optional<Vec2> intersect(const Line& l1, const Line& l2) noexcept;
 
 std::ostream& operator<<(std::ostream& out, const Line& l) noexcept;
 

--- a/packages/geom/src/line.cpp
+++ b/packages/geom/src/line.cpp
@@ -6,6 +6,16 @@ bool equal(const Line& a, const Line& b, double eps) noexcept {
     return equal(a.normal() * b.c, b.normal() * a.c, eps);
 }
 
+std::optional<Vec2> intersect(const Line& l1, const Line& l2) noexcept {
+    double det = cross(Vec2(l1.a, l1.b), Vec2(l2.a, l2.b));
+    if (det == 0) {
+        return std::nullopt;
+    }
+    return Vec2(
+        cross(Vec2(l1.b, l1.c), Vec2(l2.b, l2.c)) / det,
+        cross(Vec2(l1.c, l1.a), Vec2(l2.c, l2.a)) / det);
+}
+
 std::ostream& operator<<(std::ostream& out, const Line& l) noexcept {
     return out << "Line(" << l.a << ", " << l.b << ", " << l.c << ")";
 }

--- a/packages/geom/test/main.cpp
+++ b/packages/geom/test/main.cpp
@@ -197,6 +197,24 @@ TEST(Line, make) {
     ASSERT_GEOM_EQUAL(l, l3);
 }
 
+TEST(Line, intersect) {
+    constexpr double eps = 1e-7;
+
+    {
+        auto l1 = Line::fromTwoPoints(Vec2(0, 0), Vec2(1, 1));
+        auto l2 = Line::fromTwoPoints(Vec2(0, 1), Vec2(1, 0));
+
+        ASSERT_GEOM_EQUAL(*intersect(l1, l2), Vec2(0.5, 0.5), eps);
+    }
+
+    {
+        auto l1 = Line::fromTwoPoints(Vec2(0, 0), Vec2(0, 1));
+        auto l2 = Line::fromTwoPoints(Vec2(1, 0), Vec2(1, 1));
+
+        ASSERT_EQ(intersect(l1, l2), std::nullopt);
+    }
+}
+
 TEST(Distance, point_point) {
     const Vec2 a = {1, 1};
     const Vec2 b = {0, 2};

--- a/packages/map/CMakeLists.txt
+++ b/packages/map/CMakeLists.txt
@@ -6,6 +6,7 @@ add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 find_package(ament_cmake REQUIRED)
 find_package(geom REQUIRED)
 find_package(common REQUIRED)
+find_package(fastgrid REQUIRED)
 find_package(nlohmann_json REQUIRED)
 
 add_library(
@@ -17,6 +18,7 @@ ament_target_dependencies(
     ${PROJECT_NAME}
     geom
     common
+    fastgrid
     nlohmann_json
 )
 
@@ -31,6 +33,7 @@ ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(
     geom
     common
+    fastgrid
     nlohmann_json
 )
 
@@ -51,5 +54,12 @@ install(
     DIRECTORY data
     DESTINATION share/${PROJECT_NAME}
 )
+
+if(BUILD_TESTING)
+    find_package(ament_cmake_clang_format REQUIRED)
+    ament_clang_format(CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-format")
+
+    add_subdirectory("test")
+endif()
 
 ament_package()

--- a/packages/map/include/map/map_builder.h
+++ b/packages/map/include/map/map_builder.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "geom/complex_polygon.h"
+#include "geom/line.h"
+
+#include "fastgrid/grid.h"
 
 namespace truck::map {
 
@@ -12,7 +15,73 @@ class Map {
 
     const geom::ComplexPolygons& polygons() const;
 
+    template<typename T>
+    geom::ComplexPolygons clip(const fastgrid::Grid<T>& grid) const noexcept {
+        geom::ComplexPolygons clipped_polygons;
+        clipped_polygons.reserve(polygons_.size());
+        for (const auto& polygon : polygons_) {
+            geom::ComplexPolygon clipped_polygon;
+            if (!polygon.outer.empty()) {
+                clipped_polygon.outer = clip(grid, polygon.outer);
+            }
+            clipped_polygon.inners.reserve(polygon.inners.size());
+            for (const auto& inner : polygon.inners) {
+                if (inner.empty()) {
+                    continue;
+                }
+                auto clipped_inner = clip(grid, inner);
+                if (!clipped_inner.empty()) {
+                    clipped_polygon.inners.push_back(std::move(clipped_inner));
+                }
+            }
+            if (!clipped_polygon.outer.empty() || !clipped_polygon.inners.empty()) {
+                clipped_polygons.push_back(std::move(clipped_polygon));
+            }
+        }
+        return clipped_polygons;
+    }
+
   private:
+    template<typename T>
+    geom::Polygon clip(const fastgrid::Grid<T>& grid, const geom::Polygon& polygon) const noexcept {
+        auto pose = VERIFY(grid.origin)->pose;
+        const geom::Polygon clip_polygon{
+            pose.pos,
+            pose.pos + pose.dir.vec() * grid.resolution * grid.size.width,
+            pose.pos + pose.dir.vec() * grid.resolution * grid.size.width +
+                pose.dir.vec().left() * grid.resolution * grid.size.height,
+            pose.pos + pose.dir.vec().left() * grid.resolution * grid.size.height};
+
+        auto clipped_polygon = polygon;
+
+        auto clip_vertex_1 = clip_polygon.back();
+        for (const auto& clip_vertex_2 : clip_polygon) {
+            geom::Polygon current_polygon = clipped_polygon;
+            clipped_polygon.clear();
+            auto current_vertex_1 = current_polygon.back();
+            for (const auto& vertex : current_polygon) {
+                auto current_vertex_2 = vertex;
+                auto intersection_point = geom::intersect(
+                    geom::Line::fromTwoPoints(current_vertex_1, current_vertex_2),
+                    geom::Line::fromTwoPoints(clip_vertex_1, clip_vertex_2));
+                if (cross(current_vertex_2 - clip_vertex_1, clip_vertex_2 - clip_vertex_1) <= 0) {
+                    if (cross(current_vertex_1 - clip_vertex_1, clip_vertex_2 - clip_vertex_1) >
+                        0) {
+                        clipped_polygon.push_back(*intersection_point);
+                    }
+                    clipped_polygon.push_back(current_vertex_2);
+                } else if (
+                    cross(current_vertex_1 - clip_vertex_1, clip_vertex_2 - clip_vertex_1) < 0) {
+                    clipped_polygon.push_back(*intersection_point);
+                }
+                current_vertex_1 = current_vertex_2;
+            }
+            clip_vertex_1 = clip_vertex_2;
+        }
+
+        return clipped_polygon;
+    }
+
     geom::ComplexPolygons polygons_;
 };
 

--- a/packages/map/package.xml
+++ b/packages/map/package.xml
@@ -11,6 +11,7 @@
 
   <depend>geom</depend>
   <depend>common</depend>
+  <depend>fastgrid</depend>
   <depend>nlohmann_json</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/packages/map/src/map_builder.cpp
+++ b/packages/map/src/map_builder.cpp
@@ -15,8 +15,8 @@ Map Map::fromGeoJson(const std::string& path) {
     // iterate through every complex polygon
     for (const auto& elem : geojson_features) {
         // get list of outer (0 index) and inner polygons (1+ index) for a current complex polygon
-        auto polys_list = elem["geometry"]["coordinates"] \
-            .get<std::vector<std::vector<std::pair<double, double>>>>();
+        auto polys_list = elem["geometry"]["coordinates"]
+                              .get<std::vector<std::vector<std::pair<double, double>>>>();
 
         int polys_cnt = 0;
         geom::Polygon outer;

--- a/packages/map/test/CMakeLists.txt
+++ b/packages/map/test/CMakeLists.txt
@@ -1,0 +1,10 @@
+find_package(ament_cmake_gtest REQUIRED)
+
+ament_add_gtest(${PROJECT_NAME}_tests main.cpp)
+target_link_libraries(${PROJECT_NAME}_tests ${PROJECT_NAME})
+set_tests_properties(${Tests} PROPERTIES TIMEOUT 10)
+
+target_include_directories(${PROJECT_NAME}_tests PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")

--- a/packages/map/test/main.cpp
+++ b/packages/map/test/main.cpp
@@ -1,0 +1,75 @@
+#include <gtest/gtest.h>
+
+#include "geom/test/equal_assert.h"
+
+#include "map/map_builder.h"
+
+#include <cmath>
+#include <memory>
+#include <vector>
+
+using namespace truck::geom;
+using namespace truck::map;
+using namespace truck::fastgrid;
+
+TEST(Map, clip) {
+    {
+        const Size size = {3, 3};
+        const double resolution = 1.0;
+        const Pose pose = {{0, 0}, AngleVec2::fromVector(1, 0)};
+
+        const auto grid = Grid<uint8_t>(size, resolution, pose);
+
+        const ComplexPolygon poly(
+            {Vec2(-0.5, 0.5), Vec2(1.5, -1.5), Vec2(2, 0.5), Vec2(2.5, 1.5), Vec2(0.5, 4.5)});
+
+        auto map = Map({poly});
+
+        const auto clipped_polygons = map.clip(grid);
+
+        EXPECT_EQ(clipped_polygons.size(), 1);
+        const ComplexPolygon expected_poly(
+            {Vec2(0.125, 3),
+             Vec2(0, 2.5),
+             Vec2(0, 0),
+             Vec2(1.875, 0),
+             Vec2(2, 0.5),
+             Vec2(2.5, 1.5),
+             Vec2(1.5, 3)});
+        EXPECT_EQ(clipped_polygons[0].outer.size(), expected_poly.outer.size());
+        for (size_t i = 0; i < expected_poly.outer.size(); ++i) {
+            ASSERT_GEOM_EQUAL(clipped_polygons[0].outer[i], expected_poly.outer[i]);
+        }
+        EXPECT_TRUE(clipped_polygons[0].inners.empty());
+    }
+    {
+        const Size size = {3, 3};
+        const double resolution = 1.0;
+        const Pose pose = {{0, 0}, AngleVec2::fromVector(0, 1)};
+
+        const auto grid = Grid<uint8_t>(size, resolution, pose);
+
+        const ComplexPolygon poly(
+            {Vec2(-1.5, -0.5), Vec2(0.5, 1.5), Vec2(-1.5, 3.5), Vec2(-3.5, 1.5)});
+
+        auto map = Map({poly});
+
+        const auto clipped_polygons = map.clip(grid);
+
+        EXPECT_EQ(clipped_polygons.size(), 1);
+        const ComplexPolygon expected_poly(
+            {Vec2(-3, 1),
+             Vec2(-2, 0),
+             Vec2(-1, 0),
+             Vec2(0, 1),
+             Vec2(0, 2),
+             Vec2(-1, 3),
+             Vec2(-2, 3),
+             Vec2(-3, 2)});
+        EXPECT_EQ(clipped_polygons[0].outer.size(), expected_poly.outer.size());
+        for (size_t i = 0; i < expected_poly.outer.size(); ++i) {
+            ASSERT_GEOM_EQUAL(clipped_polygons[0].outer[i], expected_poly.outer[i]);
+        }
+        EXPECT_TRUE(clipped_polygons[0].inners.empty());
+    }
+}

--- a/packages/planner/include/planner/planner_node.h
+++ b/packages/planner/include/planner/planner_node.h
@@ -51,7 +51,6 @@ class PlannerNode : public rclcpp::Node {
 
     struct State {
         std::shared_ptr<search::Grid> grid = nullptr;
-        std::shared_ptr<collision::Map> distance_transform = nullptr;
 
         nav_msgs::msg::Odometry::SharedPtr odom = nullptr;
         nav_msgs::msg::OccupancyGrid::SharedPtr occupancy_grid = nullptr;
@@ -76,6 +75,7 @@ class PlannerNode : public rclcpp::Node {
 
     std::unique_ptr<model::Model> model_ = nullptr;
     std::unique_ptr<tf2_ros::Buffer> tf_buffer_ = nullptr;
+    std::shared_ptr<collision::CollisionMap> collision_map_ = nullptr;
     std::shared_ptr<collision::StaticCollisionChecker> checker_ = nullptr;
     rclcpp::TimerBase::SharedPtr timer_ = nullptr;
 };

--- a/packages/planner/src/planner_node.cpp
+++ b/packages/planner/src/planner_node.cpp
@@ -87,6 +87,7 @@ PlannerNode::PlannerNode() : Node("planner") {
     tf_buffer_ = std::make_unique<tf2_ros::Buffer>(this->get_clock());
     tf_buffer_->setUsingDedicatedThread(true);
 
+    collision_map_ = std::make_shared<collision::CollisionMap>();
     checker_ = std::make_shared<collision::StaticCollisionChecker>(model_->shape());
 
     timer_ = this->create_wall_timer(200ms, bind(&PlannerNode::doPlanningLoop, this));
@@ -113,13 +114,11 @@ void PlannerNode::onGrid(const nav_msgs::msg::OccupancyGrid::SharedPtr msg) {
     msg->header.frame_id = target;
     msg->info.origin = geom::msg::toPose(tf_opt->apply(geom::toPose(msg->info.origin)));
 
-    state_.distance_transform = std::make_shared<collision::Map>(
-        collision::distanceTransform(collision::Map::fromOccupancyGrid(*msg)));
-
     state_.occupancy_grid = msg;
 
     // update collision checker
-    checker_->reset(*state_.distance_transform);
+    collision_map_->SetOccupancyGrid(msg);
+    checker_->reset(collision_map_->GetDistanceMap());
 }
 
 void PlannerNode::onOdometry(const nav_msgs::msg::Odometry::SharedPtr msg) {

--- a/packages/waypoint_follower/include/waypoint_follower/waypoint_follower_node.h
+++ b/packages/waypoint_follower/include/waypoint_follower/waypoint_follower_node.h
@@ -80,12 +80,12 @@ class WaypointFollowerNode : public rclcpp::Node {
         nav_msgs::msg::Odometry::SharedPtr odometry = nullptr;
         std::optional<geom::Localization> localization = std::nullopt;
         nav_msgs::msg::OccupancyGrid::SharedPtr grid = nullptr;
-        std::shared_ptr<collision::Map> distance_transform = nullptr;
         double scheduled_velocity = 0;
     } state_;
 
     std::unique_ptr<model::Model> model_ = nullptr;
     std::unique_ptr<WaypointFollower> follower_ = nullptr;
+    std::unique_ptr<collision::CollisionMap> collision_map_ = nullptr;
     std::unique_ptr<collision::StaticCollisionChecker> checker_ = nullptr;
     std::unique_ptr<tf2_ros::Buffer> tf_buffer_ = nullptr;
 };

--- a/packages/waypoint_follower/src/waypoint_follower_node.cpp
+++ b/packages/waypoint_follower/src/waypoint_follower_node.cpp
@@ -97,6 +97,7 @@ WaypointFollowerNode::WaypointFollowerNode() : Node("waypoint_follower") {
     model_ = std::make_unique<model::Model>(
         model::load(this->get_logger(), this->declare_parameter("model_config", "")));
 
+    collision_map_ = std::make_unique<collision::CollisionMap>();
     checker_ = std::make_unique<collision::StaticCollisionChecker>(model_->shape());
 
     tf_buffer_ = std::make_unique<tf2_ros::Buffer>(this->get_clock());
@@ -150,7 +151,7 @@ motion::Trajectory makeTrajectory(const std::deque<LinkedPose>& path) {
 }  // namespace
 
 void WaypointFollowerNode::publishGridCostMap() {
-    if (!state_.distance_transform) {
+    if (!collision_map_->GetDistanceMap().data) {
         return;
     }
 
@@ -159,12 +160,12 @@ void WaypointFollowerNode::publishGridCostMap() {
     }
 
     constexpr double kMaxDistance = 10.0;
-    const auto msg = state_.distance_transform->makeCostMap(state_.grid->header, kMaxDistance);
+    const auto msg = collision_map_->MakeCostMap(state_.grid->header, kMaxDistance);
     signal_.distance_transform->publish(msg);
 }
 
 void WaypointFollowerNode::publishTrajectory() {
-    if (!state_.odometry || !state_.distance_transform) {
+    if (!state_.odometry || !collision_map_->GetDistanceMap().data) {
         return;
     }
 
@@ -176,7 +177,7 @@ void WaypointFollowerNode::publishTrajectory() {
         follower_->reset();
     }
 
-    checker_->reset(*state_.distance_transform);
+    checker_->reset(collision_map_->GetDistanceMap());
 
     motion::Trajectory trajectory = makeTrajectory(follower_->path());
     bool collision = false;
@@ -293,8 +294,7 @@ void WaypointFollowerNode::onGrid(nav_msgs::msg::OccupancyGrid::SharedPtr msg) {
     msg->info.origin = geom::msg::toPose(tf_opt->apply(geom::toPose(msg->info.origin)));
 
     // distance transfor - cpu intensive operation
-    state_.distance_transform = std::make_shared<collision::Map>(
-        collision::distanceTransform(collision::Map::fromOccupancyGrid(*msg)));
+    collision_map_->SetOccupancyGrid(msg);
 
     state_.grid = msg;
 }


### PR DESCRIPTION
- Переписал `collision::Map` на структуру `collision::CollisionMap`, хранящую буффер и состояния `occupancy_grid`'a и `distance_transform`'а с целью экономии памяти не реаллокациях `fastgrid::GridHolder`'ов и промежуточного буффера для вычисления `distance_transform`'a
- Добавил в `collision::CollisionMap` поддержку `map::Map` и проецирование "заплатки" карты на `occupancy_grid` и `distance_transform`
- Перенес ноды `planner_node` и `waypoint_follower_node` на новый `collision`