### PR TITLE
fix: remove last point from map polygon

### DIFF
--- a/packages/map/src/map.cpp
+++ b/packages/map/src/map.cpp
@@ -29,6 +29,8 @@ Map Map::fromGeoJson(const std::string& path) {
                 simple_poly.push_back(geom::Vec2(point.first, point.second));
             }
 
+            simple_poly.pop_back();  // remove last point, because it is the same as the first one
+
             if (polys_cnt == 0) {
                 outer = std::move(simple_poly);
             } else {


### PR DESCRIPTION
Мы с Андреем договорились хранить полигоны в формате [A, B, C], а не [A, B, C, A] (для консистентности всех геометрических алгоритмов, которые пишем), а geojson по дефолту имеет формат [A, B, C, A], поэтому явно выпилил последнюю точку.

Тесты не флапнули, в navigation, судя по картинкам, ничего не стрельнуло