### PR TITLE
Wheel spin visualization

### DIFF
--- a/packages/visualization/src/visualization_node.cpp
+++ b/packages/visualization/src/visualization_node.cpp
@@ -23,12 +23,13 @@ using namespace std::chrono_literals;
 
 using namespace geom::literals;
 
+const double M_2PI = M_PI * 2;
+
 VisualizationNode::VisualizationNode() : Node("visualization") {
     initializePtrFields();
     initializeParams();
     initializeTopicHandlers();
-    initializeCacheBodyBaseTf();
-    initializeCacheWheelBaseTfs();
+    initializeCache();
 }
 
 void VisualizationNode::initializePtrFields() {
@@ -162,6 +163,12 @@ void VisualizationNode::initializeCacheWheelBaseTfs() {
     }
 }
 
+void VisualizationNode::initializeCache() {
+    initializeCacheBodyBaseTf();
+    initializeCacheWheelBaseTfs();
+    cache_.last_ego_update_second = now().seconds();
+}
+
 void VisualizationNode::handleTelemetry(truck_msgs::msg::HardwareTelemetry::ConstSharedPtr msg) {
     state_.telemetry = msg;
 }
@@ -170,7 +177,7 @@ void VisualizationNode::handleOdometry(nav_msgs::msg::Odometry::ConstSharedPtr o
     state_.odom = std::move(odom);
     ++state_.odom_seq_id;
 
-    publishEgo();
+    updateEgo();
     publishEgoTrack();
     publishArc();
 }
@@ -240,7 +247,7 @@ void VisualizationNode::publishTrajectory() const {
 
 void VisualizationNode::handleMode(truck_msgs::msg::ControlMode::ConstSharedPtr msg) {
     state_.mode = std::move(msg);
-    publishEgo();
+    updateEgo();
 }
 
 namespace {
@@ -268,11 +275,24 @@ visualization_msgs::msg::Marker makeMeshMarker(int id, const std_msgs::msg::Head
 
 } // namespace
 
-void VisualizationNode::publishEgo() const {
+void VisualizationNode::updateWheelsSpin() {
+    const auto now_seconds = now().seconds();
+    const auto time = now_seconds - cache_.last_ego_update_second;
+    const auto velocity = state_.telemetry->current_rps * model_->gearRatio() * M_2PI;
+    cache_.wheels_spin_angle = std::fmod(cache_.wheels_spin_angle + velocity * time, M_2PI);
+    cache_.last_ego_update_second = now_seconds;
+}
+
+void VisualizationNode::updateEgo() {
     if (!state_.odom || !state_.mode || !state_.telemetry) {
         return;
     }
 
+    updateWheelsSpin();
+    publishEgo();
+}
+
+void VisualizationNode::publishEgo() const {
     tf2::Transform base_to_odom;
     tf2::fromMsg(state_.odom->pose.pose, base_to_odom);
 
@@ -286,19 +306,28 @@ void VisualizationNode::publishEgo() const {
     msg_array.markers.push_back(body_msg);
 
     for (auto wheel : kAllWheels) {
-        const double z_angle = [&]() {
-            switch (wheel) {
-                case WheelIndex::kFrontLeft:
-                    return state_.telemetry->current_left_steering;
-                case WheelIndex::kFrontRight:
-                    return state_.telemetry->current_right_steering;
-                default:
-                    return 0.0;
-            }
-        }();
+        double y_angle, z_angle;
+        switch (wheel) {
+            case WheelIndex::kFrontLeft:
+                y_angle = cache_.wheels_spin_angle;
+                z_angle = state_.telemetry->current_left_steering;
+                break;
+            case WheelIndex::kRearLeft:
+                y_angle = cache_.wheels_spin_angle;
+                z_angle = 0.0;
+                break;
+            case WheelIndex::kFrontRight:
+                y_angle = -cache_.wheels_spin_angle;
+                z_angle = state_.telemetry->current_right_steering;
+                break;
+            case WheelIndex::kRearRight:
+                y_angle = -cache_.wheels_spin_angle;
+                z_angle = 0.0;
+                break;
+        }
 
         auto rotation = tf2::Quaternion::getIdentity();
-        rotation.setRPY(0, 0, z_angle);
+        rotation.setRPY(0, y_angle, z_angle);
         const auto wheel_tf = base_to_odom 
             * cache_.wheel_base_tfs[wheel] * tf2::Transform(rotation);
 

--- a/packages/visualization/src/visualization_node.h
+++ b/packages/visualization/src/visualization_node.h
@@ -35,6 +35,7 @@ class VisualizationNode : public rclcpp::Node {
     void initializeTopicHandlers();
     void initializeCacheBodyBaseTf();
     void initializeCacheWheelBaseTfs();
+    void initializeCache();
 
     void handleTrajectory(truck_msgs::msg::Trajectory::ConstSharedPtr trajectory);
     void handleControl(truck_msgs::msg::Control::ConstSharedPtr control);
@@ -44,6 +45,9 @@ class VisualizationNode : public rclcpp::Node {
     void handleOdometry(nav_msgs::msg::Odometry::ConstSharedPtr msg);
     void handleNavigationMesh(truck_msgs::msg::NavigationMesh::ConstSharedPtr msg);
     void handleNavigationRoute(truck_msgs::msg::NavigationRoute::ConstSharedPtr msg);
+
+    void updateWheelsSpin();
+    void updateEgo();
 
     void publishTrajectory() const;
     void publishEgo() const;
@@ -113,6 +117,8 @@ class VisualizationNode : public rclcpp::Node {
     struct Cache {
         tf2::Transform body_base_tf;
         std::array<tf2::Transform, 4> wheel_base_tfs;
+        double wheels_spin_angle = 0.0;
+        double last_ego_update_second;
     } cache_;
 
     std::unique_ptr<model::Model> model_ = nullptr;


### PR DESCRIPTION
В пакет visualization добавлено вращение маркеров колёс.
Вычисления основаны на значении current_rps из сообщения truck::msg::HardwareTelemetry (топик "/hardware/telemetry").
Эта реализация должна одинаково хорошо работать и для симуляции, и для реального трака.