### PR TITLE
Advanced wheels spin visualization

### DIFF
--- a/packages/hardware_node/hardware_node/node.py
+++ b/packages/hardware_node/hardware_node/node.py
@@ -208,7 +208,7 @@ class HardwareNode(Node):
             rear_left_wheel_velocity=wheel_velocity.rear_left,
             rear_right_wheel_velocity=wheel_velocity.rear_right,
             front_left_wheel_velocity=wheel_velocity.front_left,
-            front_right_wheel_velocity=wheel_velocity.front_right
+            front_right_wheel_velocity=wheel_velocity.front_right,
         )
 
         self._telemetry_pub.publish(telemetry)

--- a/packages/hardware_node/hardware_node/node.py
+++ b/packages/hardware_node/hardware_node/node.py
@@ -145,7 +145,7 @@ class HardwareNode(Node):
         self._log.debug(f"Center curvature: {msg.curvature:.2f}")
         self._log.debug(f"Rear curvature: {twist.curvature:.2f}")
         self._teensy.push(steering.left.radians, steering.right.radians)
-        self._cache.target_rear_curvature = twist.curvature
+        self._cache.target_curvature = msg.curvature
 
     def _push_status(self):
         armed = self._axis.current_state != odrive.enums.AXIS_STATE_IDLE
@@ -189,7 +189,7 @@ class HardwareNode(Node):
 
         rps = self._axis.encoder.vel_estimate
         vel = self._model.motor_rps_to_linear_velocity(rps)
-        curv = self._cache.target_rear_curvature
+        curv = self._cache.target_curvature
         twist = pymodel.Twist(vel, curv)
         twist = self._model.base_to_rear_twist(twist)
         steering = self._model.rear_twist_to_steering(twist)

--- a/packages/hardware_node/hardware_node/node.py
+++ b/packages/hardware_node/hardware_node/node.py
@@ -24,6 +24,7 @@ class HardwareNode(Node):
         self._init_odrive()
         self._prev_mode = ControlMode.OFF
         self._log.info("Hardware node initialized")
+        self._cache = {}
 
     def _init_ros_params(self):
         self.declare_parameter("model_config", "")
@@ -144,6 +145,7 @@ class HardwareNode(Node):
         self._log.debug(f"Center curvature: {msg.curvature:.2f}")
         self._log.debug(f"Rear curvature: {twist.curvature:.2f}")
         self._teensy.push(steering.left.radians, steering.right.radians)
+        self._cache.target_rear_curvature = twist.curvature
 
     def _push_status(self):
         armed = self._axis.current_state != odrive.enums.AXIS_STATE_IDLE
@@ -185,17 +187,26 @@ class HardwareNode(Node):
     def _push_telemetry(self):
         header = Header(stamp=self.get_clock().now().to_msg(), frame_id="base")
 
+        rps = self._axis.encoder.vel_estimate
+        vel = self._model.motor_rps_to_linear_velocity(rps)
+        curv = self._cache.target_rear_curvature
+        twist = pymodel.Twist(vel, curv)
+        twist = self._model.base_to_rear_twist(twist)
+        steering = self._model.rear_twist_to_steering(twist)
+
         telemetry = HardwareTelemetry(
             header=header,
-            current_rps=self._axis.encoder.vel_estimate,
+            current_rps=rps,
             target_rps=self._axis.controller.input_vel,
             battery_voltage=self._odrive.vbus_voltage,
             battery_current=self._odrive.ibus,
+            current_left_steering = steering.left.radians,
+            current_right_steering = steering.right.radians,
+            rear_curvature=twist.curvature,
+            rear_velocity=twist.velocity
         )
 
         self._telemetry_pub.publish(telemetry)
-
-        vel = self._model.motor_rps_to_linear_velocity(telemetry.current_rps)
 
         odom = Odometry(header=header)
         odom.twist.twist.linear = Vector3(x=float(vel), y=0.0, z=0.0)

--- a/packages/hardware_node/hardware_node/node.py
+++ b/packages/hardware_node/hardware_node/node.py
@@ -200,10 +200,10 @@ class HardwareNode(Node):
             target_rps=self._axis.controller.input_vel,
             battery_voltage=self._odrive.vbus_voltage,
             battery_current=self._odrive.ibus,
-            current_left_steering = steering.left.radians,
-            current_right_steering = steering.right.radians,
+            current_left_steering=steering.left.radians,
+            current_right_steering=steering.right.radians,
             rear_curvature=twist.curvature,
-            rear_velocity=twist.velocity
+            rear_velocity=twist.velocity,
         )
 
         self._telemetry_pub.publish(telemetry)

--- a/packages/model/include/model/model.h
+++ b/packages/model/include/model/model.h
@@ -24,9 +24,10 @@ struct Steering {
 };
 
 struct WheelVelocity {
-    geom::Angle left;
-    geom::Angle right;
-    geom::Angle rear;
+    geom::Angle rear_left;
+    geom::Angle rear_right;
+    geom::Angle front_left;
+    geom::Angle front_right;
 };
 
 struct Twist {
@@ -99,6 +100,8 @@ class Model {
   private:
     struct Cache {
         double width_half;
+        double width_half_squared;
+        double length_squared;
         double max_abs_curvature;
         Limits<double> middle_steering_limits;
         Limits<double> base_curvature_limits;

--- a/packages/model/include/model/model.h
+++ b/packages/model/include/model/model.h
@@ -26,6 +26,7 @@ struct Steering {
 struct WheelVelocity {
     geom::Angle left;
     geom::Angle right;
+    geom::Angle rear;
 };
 
 struct Twist {
@@ -87,6 +88,7 @@ class Model {
     Steering rearCurvatureToSteering(double curvature) const;
     double middleSteeringToRearCurvature(double steering) const;
     double baseToRearAcceleration(double acceleration, double base_curvature) const;
+    WheelVelocity rearSpinToWheelVelocity(double rear_curvature, double rear_spin_velocity) const;
     WheelVelocity rearTwistToWheelVelocity(Twist rear_twist) const;
     double linearVelocityToMotorRPS(double velocity) const;
     double motorRPStoLinearVelocity(double rps) const;

--- a/packages/model/src/model.cpp
+++ b/packages/model/src/model.cpp
@@ -161,24 +161,24 @@ Steering Model::rearTwistToSteering(Twist rear_twist) const {
 
 WheelVelocity Model::rearSpinToWheelVelocity(
     double rear_curvature, double rear_spin_velocity) const {
-
     const double rear_curvature_squared = squared(rear_curvature);
 
     const double rear_ratio = rear_curvature * cache_.width_half;
     const double front_left_ratio_squared = 1 + rear_curvature_squared * cache_.width_half_squared
-        - rear_curvature * params_.wheel_base.width + cache_.length_squared;
+                                            - rear_curvature * params_.wheel_base.width
+                                            + cache_.length_squared;
     const double front_right_ratio_squared = 1 + rear_curvature_squared * cache_.length_squared;
 
-    return WheelVelocity {
+    return WheelVelocity{
         geom::Angle{(1 - rear_ratio) * rear_spin_velocity},
         geom::Angle{(1 + rear_ratio) * rear_spin_velocity},
         geom::Angle{sqrt(front_left_ratio_squared) * rear_spin_velocity},
-        geom::Angle{sqrt(front_right_ratio_squared) * rear_spin_velocity}
-    };
+        geom::Angle{sqrt(front_right_ratio_squared) * rear_spin_velocity}};
 }
 
 WheelVelocity Model::rearTwistToWheelVelocity(Twist rear_twist) const {
-    return rearSpinToWheelVelocity(rear_twist.curvature, rear_twist.velocity / params_.wheel.radius);
+    return rearSpinToWheelVelocity(
+        rear_twist.curvature, rear_twist.velocity / params_.wheel.radius);
 }
 
 double Model::linearVelocityToMotorRPS(double velocity) const {

--- a/packages/model/src/model.cpp
+++ b/packages/model/src/model.cpp
@@ -164,13 +164,12 @@ WheelVelocity Model::rearTwistToWheelVelocity(Twist rear_twist) const {
     const double rear_curvature_squared = squared(rear_twist.curvature);
 
     const double rear_ratio = rear_twist.curvature * cache_.width_half;
-    const double front_ratio_base_squared =
-        1 + rear_curvature_squared * cache_.width_half_squared
-        + rear_curvature_squared * cache_.length_squared;
-    const double front_left_ratio = sqrt(front_ratio_base_squared
-        - rear_twist.curvature * params_.wheel_base.width);
-    const double front_right_ratio = sqrt(front_ratio_base_squared
-        + rear_twist.curvature * params_.wheel_base.width);
+    const double front_ratio_base_squared = 1 + rear_curvature_squared * cache_.width_half_squared
+                                            + rear_curvature_squared * cache_.length_squared;
+    const double front_left_ratio =
+        sqrt(front_ratio_base_squared - rear_twist.curvature * params_.wheel_base.width);
+    const double front_right_ratio =
+        sqrt(front_ratio_base_squared + rear_twist.curvature * params_.wheel_base.width);
 
     return WheelVelocity{
         geom::Angle{(1 - rear_ratio) * rear_spin_velocity},

--- a/packages/model/src/model.cpp
+++ b/packages/model/src/model.cpp
@@ -164,10 +164,13 @@ WheelVelocity Model::rearTwistToWheelVelocity(Twist rear_twist) const {
     const double rear_curvature_squared = squared(rear_twist.curvature);
 
     const double rear_ratio = rear_twist.curvature * cache_.width_half;
-    const double front_left_ratio = sqrt(
+    const double front_ratio_base_squared =
         1 + rear_curvature_squared * cache_.width_half_squared
-        - rear_twist.curvature * params_.wheel_base.width + cache_.length_squared);
-    const double front_right_ratio = sqrt(1 + rear_curvature_squared * cache_.length_squared);
+        + rear_curvature_squared * cache_.length_squared;
+    const double front_left_ratio = sqrt(front_ratio_base_squared
+        - rear_twist.curvature * params_.wheel_base.width);
+    const double front_right_ratio = sqrt(front_ratio_base_squared
+        + rear_twist.curvature * params_.wheel_base.width);
 
     return WheelVelocity{
         geom::Angle{(1 - rear_ratio) * rear_spin_velocity},

--- a/packages/model/src/model.cpp
+++ b/packages/model/src/model.cpp
@@ -157,12 +157,20 @@ Steering Model::rearTwistToSteering(Twist rear_twist) const {
     return rearCurvatureToSteering(rear_twist.curvature);
 }
 
-WheelVelocity Model::rearTwistToWheelVelocity(Twist rear_twist) const {
-    const double ratio = rear_twist.curvature * cache_.width_half;
+WheelVelocity Model::rearSpinToWheelVelocity(
+    double rear_curvature, double rear_spin_velocity) const {
 
-    return WheelVelocity{
-        geom::Angle{(1 - ratio) * rear_twist.velocity / params_.wheel.radius},
-        geom::Angle{(1 + ratio) * rear_twist.velocity / params_.wheel.radius}};
+    const double ratio = rear_curvature * cache_.width_half;
+
+    return WheelVelocity {
+        geom::Angle{(1 - ratio) * rear_spin_velocity},
+        geom::Angle{(1 + ratio) * rear_spin_velocity},
+        geom::Angle{rear_spin_velocity}
+    };
+}
+
+WheelVelocity Model::rearTwistToWheelVelocity(Twist rear_twist) const {
+    return rearSpinToWheelVelocity(rear_twist.curvature, rear_twist.velocity / params_.wheel.radius);
 }
 
 double Model::linearVelocityToMotorRPS(double velocity) const {

--- a/packages/model/src/model.cpp
+++ b/packages/model/src/model.cpp
@@ -159,26 +159,21 @@ Steering Model::rearTwistToSteering(Twist rear_twist) const {
     return rearCurvatureToSteering(rear_twist.curvature);
 }
 
-WheelVelocity Model::rearSpinToWheelVelocity(
-    double rear_curvature, double rear_spin_velocity) const {
-    const double rear_curvature_squared = squared(rear_curvature);
+WheelVelocity Model::rearTwistToWheelVelocity(Twist rear_twist) const {
+    const double rear_spin_velocity = rear_twist.velocity / params_.wheel.radius;
+    const double rear_curvature_squared = squared(rear_twist.curvature);
 
-    const double rear_ratio = rear_curvature * cache_.width_half;
-    const double front_left_ratio_squared = 1 + rear_curvature_squared * cache_.width_half_squared
-                                            - rear_curvature * params_.wheel_base.width
-                                            + cache_.length_squared;
-    const double front_right_ratio_squared = 1 + rear_curvature_squared * cache_.length_squared;
+    const double rear_ratio = rear_twist.curvature * cache_.width_half;
+    const double front_left_ratio = sqrt(
+        1 + rear_curvature_squared * cache_.width_half_squared
+        - rear_twist.curvature * params_.wheel_base.width + cache_.length_squared);
+    const double front_right_ratio = sqrt(1 + rear_curvature_squared * cache_.length_squared);
 
     return WheelVelocity{
         geom::Angle{(1 - rear_ratio) * rear_spin_velocity},
         geom::Angle{(1 + rear_ratio) * rear_spin_velocity},
-        geom::Angle{sqrt(front_left_ratio_squared) * rear_spin_velocity},
-        geom::Angle{sqrt(front_right_ratio_squared) * rear_spin_velocity}};
-}
-
-WheelVelocity Model::rearTwistToWheelVelocity(Twist rear_twist) const {
-    return rearSpinToWheelVelocity(
-        rear_twist.curvature, rear_twist.velocity / params_.wheel.radius);
+        geom::Angle{front_left_ratio * rear_spin_velocity},
+        geom::Angle{front_right_ratio * rear_spin_velocity}};
 }
 
 double Model::linearVelocityToMotorRPS(double velocity) const {

--- a/packages/model/src/pybind.cpp
+++ b/packages/model/src/pybind.cpp
@@ -10,12 +10,12 @@ std::string to_string(const T& obj);
 
 template<>
 std::string to_string<double>(const double& obj) {
-    return boost::str(boost::format("%.5d") % obj);
+    return boost::str(boost::format("%.5f") % obj);
 }
 
 template<>
 std::string to_string<geom::Angle>(const geom::Angle& obj) {
-    return boost::str(boost::format("Angle(%.1d deg)") % obj.degrees());
+    return boost::str(boost::format("Angle(%.5f deg)") % obj.degrees());
 }
 
 template<>
@@ -35,7 +35,7 @@ std::string to_string<model::WheelVelocity>(const model::WheelVelocity& obj) {
 template<>
 std::string to_string<model::Twist>(const model::Twist& obj) {
     return boost::str(
-        boost::format("Twist(curvature=%.5d, velocity=%.5d)") % obj.curvature % obj.velocity);
+        boost::format("Twist(curvature=%.5f, velocity=%.5f)") % obj.curvature % obj.velocity);
 }
 
 template<>

--- a/packages/model/src/pybind.cpp
+++ b/packages/model/src/pybind.cpp
@@ -27,8 +27,12 @@ std::string to_string<model::Steering>(const model::Steering& obj) {
 template<>
 std::string to_string<model::WheelVelocity>(const model::WheelVelocity& obj) {
     return boost::str(
-        boost::format("WheelVelocity(left=%s, right=%s)") % to_string(obj.left)
-        % to_string(obj.right));
+        boost::format("WheelVelocity(rear_left=%s, rear_right=%s, front_left=%s, front_right=%s)")
+        % to_string(obj.rear_left)
+        % to_string(obj.rear_right)
+        % to_string(obj.front_left)
+        % to_string(obj.front_right)
+    );
 }
 
 template<>
@@ -69,8 +73,10 @@ PYBIND11_MODULE(pymodel, m) {
         .def_readonly("right", &model::Steering::right)
         .def("__repr__", &to_string<model::Steering>);
     py::class_<model::WheelVelocity>(m, "WheelVelocity")
-        .def_readonly("left", &model::WheelVelocity::left)
-        .def_readonly("right", &model::WheelVelocity::right)
+        .def_readonly("rear_left", &model::WheelVelocity::rear_left)
+        .def_readonly("rear_right", &model::WheelVelocity::rear_right)
+        .def_readonly("front_left", &model::WheelVelocity::front_left)
+        .def_readonly("front_right", &model::WheelVelocity::front_right)
         .def("__repr__", &to_string<model::WheelVelocity>);
     py::class_<model::Twist>(m, "Twist")
         .def(py::init<double, double>())

--- a/packages/model/src/pybind.cpp
+++ b/packages/model/src/pybind.cpp
@@ -28,11 +28,8 @@ template<>
 std::string to_string<model::WheelVelocity>(const model::WheelVelocity& obj) {
     return boost::str(
         boost::format("WheelVelocity(rear_left=%s, rear_right=%s, front_left=%s, front_right=%s)")
-        % to_string(obj.rear_left)
-        % to_string(obj.rear_right)
-        % to_string(obj.front_left)
-        % to_string(obj.front_right)
-    );
+        % to_string(obj.rear_left) % to_string(obj.rear_right) % to_string(obj.front_left)
+        % to_string(obj.front_right));
 }
 
 template<>

--- a/packages/simulator_2d/include/simulator_2d/truck_state.h
+++ b/packages/simulator_2d/include/simulator_2d/truck_state.h
@@ -23,7 +23,7 @@ class TruckState {
     const std::vector<float>& lidarRanges() const;
     double currentMotorRps() const;
     double targetMotorRps() const;
-    model::WheelVelocity wheelVelocity() const;
+    const& model::WheelVelocity wheelVelocity() const;
     geom::Vec3 gyroAngularVelocity() const;
     geom::Vec3 accelLinearAcceleration() const;
 
@@ -38,9 +38,9 @@ class TruckState {
     TruckState& lidarRanges(std::vector<float> lidar_ranges);
     TruckState& currentMotorRps(double current_rps);
     TruckState& targetMotorRps(double target_rps);
-    TruckState& wheelVelocity(model::WheelVelocity wheel_velocity);
-    TruckState& gyroAngularVelocity(geom::Vec3 angular_velocity);
-    TruckState& accelLinearAcceleration(geom::Vec3 linear_acceleration);
+    TruckState& wheelVelocity(const model::WheelVelocity& wheel_velocity);
+    TruckState& gyroAngularVelocity(const geom::Vec3& angular_velocity);
+    TruckState& accelLinearAcceleration(const geom::Vec3& linear_acceleration);
 
   private:
     struct Cache {

--- a/packages/simulator_2d/include/simulator_2d/truck_state.h
+++ b/packages/simulator_2d/include/simulator_2d/truck_state.h
@@ -23,7 +23,7 @@ class TruckState {
     const std::vector<float>& lidarRanges() const;
     double currentMotorRps() const;
     double targetMotorRps() const;
-    const& model::WheelVelocity wheelVelocity() const;
+    const model::WheelVelocity& wheelVelocity() const;
     geom::Vec3 gyroAngularVelocity() const;
     geom::Vec3 accelLinearAcceleration() const;
 

--- a/packages/simulator_2d/include/simulator_2d/truck_state.h
+++ b/packages/simulator_2d/include/simulator_2d/truck_state.h
@@ -18,6 +18,7 @@ class TruckState {
     model::Steering currentSteering() const;
     model::Steering targetSteering() const;
     model::Twist baseTwist() const;
+    model::Twist rearTwist() const;
     geom::Vec2 odomBaseLinearVelocity() const;
     double baseAngularVelocity() const;
     const std::vector<float>& lidarRanges() const;
@@ -32,6 +33,7 @@ class TruckState {
     TruckState& currentSteering(const model::Steering& current_steering);
     TruckState& targetSteering(const model::Steering& target_steering);
     TruckState& baseTwist(const model::Twist& twist);
+    TruckState& rearTwist(const model::Twist& twist);
     TruckState& odomBaseLinearVelocity(const geom::Vec2& linear_velocity);
     TruckState& baseAngularVelocity(double angular_velocity);
     TruckState& lidarRanges(std::vector<float> lidar_ranges);
@@ -48,6 +50,7 @@ class TruckState {
         model::Steering current_steering;
         model::Steering target_steering;
         model::Twist base_odom_twist;
+        model::Twist rear_twist;
         geom::Vec2 base_odom_linear_velocity;
         double base_odom_angular_velocity;
         std::vector<float> lidar_ranges;

--- a/packages/simulator_2d/include/simulator_2d/truck_state.h
+++ b/packages/simulator_2d/include/simulator_2d/truck_state.h
@@ -18,12 +18,12 @@ class TruckState {
     model::Steering currentSteering() const;
     model::Steering targetSteering() const;
     model::Twist baseTwist() const;
-    model::Twist rearTwist() const;
     geom::Vec2 odomBaseLinearVelocity() const;
     double baseAngularVelocity() const;
     const std::vector<float>& lidarRanges() const;
     double currentMotorRps() const;
     double targetMotorRps() const;
+    model::WheelVelocity wheelVelocity() const;
     geom::Vec3 gyroAngularVelocity() const;
     geom::Vec3 accelLinearAcceleration() const;
 
@@ -33,12 +33,12 @@ class TruckState {
     TruckState& currentSteering(const model::Steering& current_steering);
     TruckState& targetSteering(const model::Steering& target_steering);
     TruckState& baseTwist(const model::Twist& twist);
-    TruckState& rearTwist(const model::Twist& twist);
     TruckState& odomBaseLinearVelocity(const geom::Vec2& linear_velocity);
     TruckState& baseAngularVelocity(double angular_velocity);
     TruckState& lidarRanges(std::vector<float> lidar_ranges);
     TruckState& currentMotorRps(double current_rps);
     TruckState& targetMotorRps(double target_rps);
+    TruckState& wheelVelocity(model::WheelVelocity wheel_velocity);
     TruckState& gyroAngularVelocity(geom::Vec3 angular_velocity);
     TruckState& accelLinearAcceleration(geom::Vec3 linear_acceleration);
 
@@ -50,12 +50,12 @@ class TruckState {
         model::Steering current_steering;
         model::Steering target_steering;
         model::Twist base_odom_twist;
-        model::Twist rear_twist;
         geom::Vec2 base_odom_linear_velocity;
         double base_odom_angular_velocity;
         std::vector<float> lidar_ranges;
         double current_motor_rps;
         double target_motor_rps;
+        model::WheelVelocity wheel_velocity;
         geom::Vec3 gyro_angular_velocity;
         geom::Vec3 accel_linear_acceleration;
     } cache_;

--- a/packages/simulator_2d/src/simulator_engine.cpp
+++ b/packages/simulator_2d/src/simulator_engine.cpp
@@ -187,6 +187,7 @@ TruckState SimulatorEngine::getTruckState() const {
     auto lidar_ranges = getLidarRanges(map_, lidar_pose, model_->lidar(), params_.precision);
     const auto current_rps = model_->linearVelocityToMotorRPS(twist.velocity);
     const auto target_rps = model_->linearVelocityToMotorRPS(control_.velocity);
+    const auto wheel_velocity = model_->rearTwistToWheelVelocity(rear_twist);
     const auto gyro_angular_velocity = getImuAngularVelocity(angular_velocity);
     const auto accel_linear_acceleration = getImuLinearAcceleration(rear_twist);
 
@@ -197,12 +198,12 @@ TruckState SimulatorEngine::getTruckState() const {
         .currentSteering(current_steering)
         .targetSteering(target_steering)
         .baseTwist(twist)
-        .rearTwist(rear_twist)
         .odomBaseLinearVelocity(linear_velocity)
         .baseAngularVelocity(angular_velocity)
         .lidarRanges(std::move(lidar_ranges))
         .currentMotorRps(current_rps)
         .targetMotorRps(target_rps)
+        .wheelVelocity(wheel_velocity)
         .gyroAngularVelocity(gyro_angular_velocity)
         .accelLinearAcceleration(accel_linear_acceleration);
 }

--- a/packages/simulator_2d/src/simulator_engine.cpp
+++ b/packages/simulator_2d/src/simulator_engine.cpp
@@ -197,6 +197,7 @@ TruckState SimulatorEngine::getTruckState() const {
         .currentSteering(current_steering)
         .targetSteering(target_steering)
         .baseTwist(twist)
+        .rearTwist(rear_twist)
         .odomBaseLinearVelocity(linear_velocity)
         .baseAngularVelocity(angular_velocity)
         .lidarRanges(std::move(lidar_ranges))

--- a/packages/simulator_2d/src/simulator_node.cpp
+++ b/packages/simulator_2d/src/simulator_node.cpp
@@ -170,8 +170,11 @@ void SimulatorNode::publishTelemetryMessage(const TruckState& truck_state) {
     telemetry_msg.current_rps = truck_state.currentMotorRps();
     telemetry_msg.target_rps = truck_state.targetMotorRps();
 
-    telemetry_msg.rear_curvature = truck_state.rearTwist().curvature;
-    telemetry_msg.rear_velocity = truck_state.rearTwist().velocity;
+    const auto wheel_velocity = truck_state.wheel_velocity();
+    telemetry_msg.rear_left_wheel_velocity = wheel_velocity.rear_left.radians();
+    telemetry_msg.rear_right_wheel_velocity = wheel_velocity.rear_right.radians();
+    telemetry_msg.front_left_wheel_velocity = wheel_velocity.front_left.radians();
+    telemetry_msg.front_right_wheel_velocity = wheel_velocity.front_right.radians();
 
     signals_.telemetry->publish(telemetry_msg);
 }

--- a/packages/simulator_2d/src/simulator_node.cpp
+++ b/packages/simulator_2d/src/simulator_node.cpp
@@ -170,7 +170,7 @@ void SimulatorNode::publishTelemetryMessage(const TruckState& truck_state) {
     telemetry_msg.current_rps = truck_state.currentMotorRps();
     telemetry_msg.target_rps = truck_state.targetMotorRps();
 
-    const auto wheel_velocity = truck_state.wheel_velocity();
+    const auto wheel_velocity = truck_state.wheelVelocity();
     telemetry_msg.rear_left_wheel_velocity = wheel_velocity.rear_left.radians();
     telemetry_msg.rear_right_wheel_velocity = wheel_velocity.rear_right.radians();
     telemetry_msg.front_left_wheel_velocity = wheel_velocity.front_left.radians();

--- a/packages/simulator_2d/src/simulator_node.cpp
+++ b/packages/simulator_2d/src/simulator_node.cpp
@@ -170,6 +170,9 @@ void SimulatorNode::publishTelemetryMessage(const TruckState& truck_state) {
     telemetry_msg.current_rps = truck_state.currentMotorRps();
     telemetry_msg.target_rps = truck_state.targetMotorRps();
 
+    telemetry_msg.rear_curvature = truck_state.rearTwist().curvature;
+    telemetry_msg.rear_velocity = truck_state.rearTwist().velocity;
+
     signals_.telemetry->publish(telemetry_msg);
 }
 

--- a/packages/simulator_2d/src/truck_state.cpp
+++ b/packages/simulator_2d/src/truck_state.cpp
@@ -27,7 +27,7 @@ double TruckState::currentMotorRps() const { return cache_.current_motor_rps; }
 
 double TruckState::targetMotorRps() const { return cache_.target_motor_rps; }
 
-const& model::WheelVelocity TruckState::wheelVelocity() const { return cache_.wheel_velocity; }
+const model::WheelVelocity& TruckState::wheelVelocity() const { return cache_.wheel_velocity; }
 
 geom::Vec3 TruckState::gyroAngularVelocity() const { return cache_.gyro_angular_velocity; }
 

--- a/packages/simulator_2d/src/truck_state.cpp
+++ b/packages/simulator_2d/src/truck_state.cpp
@@ -17,6 +17,8 @@ model::Steering TruckState::targetSteering() const { return cache_.target_steeri
 
 model::Twist TruckState::baseTwist() const { return cache_.base_odom_twist; }
 
+model::Twist TruckState::rearTwist() const { return cache_.rear_twist; }
+
 geom::Vec2 TruckState::odomBaseLinearVelocity() const { return cache_.base_odom_linear_velocity; }
 
 double TruckState::baseAngularVelocity() const { return cache_.base_odom_angular_velocity; }
@@ -58,6 +60,11 @@ TruckState& TruckState::targetSteering(const model::Steering& target_steering) {
 
 TruckState& TruckState::baseTwist(const model::Twist& twist) {
     cache_.base_odom_twist = twist;
+    return *this;
+}
+
+TruckState& TruckState::rearTwist(const model::Twist& twist) {
+    cache_.rear_twist = twist;
     return *this;
 }
 

--- a/packages/simulator_2d/src/truck_state.cpp
+++ b/packages/simulator_2d/src/truck_state.cpp
@@ -17,8 +17,6 @@ model::Steering TruckState::targetSteering() const { return cache_.target_steeri
 
 model::Twist TruckState::baseTwist() const { return cache_.base_odom_twist; }
 
-model::Twist TruckState::rearTwist() const { return cache_.rear_twist; }
-
 geom::Vec2 TruckState::odomBaseLinearVelocity() const { return cache_.base_odom_linear_velocity; }
 
 double TruckState::baseAngularVelocity() const { return cache_.base_odom_angular_velocity; }
@@ -28,6 +26,8 @@ const std::vector<float>& TruckState::lidarRanges() const { return cache_.lidar_
 double TruckState::currentMotorRps() const { return cache_.current_motor_rps; }
 
 double TruckState::targetMotorRps() const { return cache_.target_motor_rps; }
+
+model::WheelVelocity TruckState::wheelVelocity() const { return cache_.wheel_velocity; }
 
 geom::Vec3 TruckState::gyroAngularVelocity() const { return cache_.gyro_angular_velocity; }
 
@@ -63,10 +63,6 @@ TruckState& TruckState::baseTwist(const model::Twist& twist) {
     return *this;
 }
 
-TruckState& TruckState::rearTwist(const model::Twist& twist) {
-    cache_.rear_twist = twist;
-    return *this;
-}
 
 TruckState& TruckState::odomBaseLinearVelocity(const geom::Vec2& linear_velocity) {
     cache_.base_odom_linear_velocity = linear_velocity;
@@ -90,6 +86,11 @@ TruckState& TruckState::currentMotorRps(double current_rps) {
 
 TruckState& TruckState::targetMotorRps(double target_rps) {
     cache_.target_motor_rps = target_rps;
+    return *this;
+}
+
+TruckState& TruckState::wheelVelocity(model::WheelVelocity wheel_velocity) {
+    cache_.wheel_velocity = wheel_velocity;
     return *this;
 }
 

--- a/packages/simulator_2d/src/truck_state.cpp
+++ b/packages/simulator_2d/src/truck_state.cpp
@@ -27,7 +27,7 @@ double TruckState::currentMotorRps() const { return cache_.current_motor_rps; }
 
 double TruckState::targetMotorRps() const { return cache_.target_motor_rps; }
 
-model::WheelVelocity TruckState::wheelVelocity() const { return cache_.wheel_velocity; }
+const& model::WheelVelocity TruckState::wheelVelocity() const { return cache_.wheel_velocity; }
 
 geom::Vec3 TruckState::gyroAngularVelocity() const { return cache_.gyro_angular_velocity; }
 
@@ -88,17 +88,17 @@ TruckState& TruckState::targetMotorRps(double target_rps) {
     return *this;
 }
 
-TruckState& TruckState::wheelVelocity(model::WheelVelocity wheel_velocity) {
+TruckState& TruckState::wheelVelocity(const model::WheelVelocity& wheel_velocity) {
     cache_.wheel_velocity = wheel_velocity;
     return *this;
 }
 
-TruckState& TruckState::gyroAngularVelocity(geom::Vec3 angular_velocity) {
+TruckState& TruckState::gyroAngularVelocity(const geom::Vec3& angular_velocity) {
     cache_.gyro_angular_velocity = angular_velocity;
     return *this;
 }
 
-TruckState& TruckState::accelLinearAcceleration(geom::Vec3 linear_acceleration) {
+TruckState& TruckState::accelLinearAcceleration(const geom::Vec3& linear_acceleration) {
     cache_.accel_linear_acceleration = linear_acceleration;
     return *this;
 }

--- a/packages/simulator_2d/src/truck_state.cpp
+++ b/packages/simulator_2d/src/truck_state.cpp
@@ -63,7 +63,6 @@ TruckState& TruckState::baseTwist(const model::Twist& twist) {
     return *this;
 }
 
-
 TruckState& TruckState::odomBaseLinearVelocity(const geom::Vec2& linear_velocity) {
     cache_.base_odom_linear_velocity = linear_velocity;
     return *this;

--- a/packages/truck_gazebo_plugins/src/ackermann_model.cpp
+++ b/packages/truck_gazebo_plugins/src/ackermann_model.cpp
@@ -114,11 +114,11 @@ void AckermannModelPlugin::OnUpdate(const common::UpdateInfo& info) {
         }
 
         const double velocity_left_force =
-            velocity_left_pd_.Update(velocity_left - wheel_velocity.left.radians(), delta);
+            velocity_left_pd_.Update(velocity_left - wheel_velocity.rear_left.radians(), delta);
         rear_left_joint_->SetForce(0, velocity_left_force);
 
         const double velocity_right_force =
-            velocity_right_pd_.Update(velocity_right - wheel_velocity.right.radians(), delta);
+            velocity_right_pd_.Update(velocity_right - wheel_velocity.rear_right.radians(), delta);
         rear_right_joint_->SetForce(0, velocity_right_force);
     };
 

--- a/packages/truck_msgs/msg/HardwareTelemetry.msg
+++ b/packages/truck_msgs/msg/HardwareTelemetry.msg
@@ -1,13 +1,18 @@
 std_msgs/Header header
-float64 current_rps            # RPS
-float64 target_rps             # RPS
-float64 battery_voltage        # Volts
-float64 battery_current        # Amps
 
-float64 target_left_steering   # Radians
-float64 current_left_steering  # Radians
-float64 target_right_steering  # Radians
-float64 current_right_steering # Radians
+# CORE
+float64 current_rps                # RPS
+float64 target_rps                 # RPS
+float64 battery_voltage            # Volts
+float64 battery_current            # Amps
 
-float64 rear_curvature         # 1/m
-float64 rear_velocity          # m/s
+# WHEELS
+float64 target_left_steering       # rad
+float64 current_left_steering      # rad
+float64 target_right_steering      # rad
+float64 current_right_steering     # rad
+
+float64 rear_left_wheel_velocity   # rad/s
+float64 rear_right_wheel_velocity  # rad/s
+float64 front_left_wheel_velocity  # rad/s
+float64 front_right_wheel_velocity # rad/s

--- a/packages/truck_msgs/msg/HardwareTelemetry.msg
+++ b/packages/truck_msgs/msg/HardwareTelemetry.msg
@@ -8,3 +8,6 @@ float64 target_left_steering   # Radians
 float64 current_left_steering  # Radians
 float64 target_right_steering  # Radians
 float64 current_right_steering # Radians
+
+float64 rear_curvature         # 1/m
+float64 rear_velocity          # m/s

--- a/packages/visualization/src/visualization_node.cpp
+++ b/packages/visualization/src/visualization_node.cpp
@@ -265,7 +265,7 @@ visualization_msgs::msg::Marker makeMeshMarker(
 
 void VisualizationNode::updateWheelsSpin() {
     const auto now_seconds = now().seconds();
-    const auto before = state_.last_ego_update_second.value_or(now_seconds);
+    const auto before = state_.last_ego_update_seconds.value_or(now_seconds);
     const auto time = now_seconds - before;
 
     const model::WheelVelocity wheel_velocity = {

--- a/packages/visualization/src/visualization_node.cpp
+++ b/packages/visualization/src/visualization_node.cpp
@@ -267,12 +267,11 @@ visualization_msgs::msg::Marker makeMeshMarker(
 void VisualizationNode::updateWheelsSpin() {
     const auto now_seconds = now().seconds();
     const auto time = now_seconds - cache_.last_ego_update_second;
-
-    const model::WheelVelocity wheel_velocity;
-    wheel_velocity.rear_left = geom::Angle(state_.telemetry->rear_left_wheel_velocity);
-    wheel_velocity.rear_right = geom::Angle(state_.telemetry->rear_right_wheel_velocity);
-    wheel_velocity.front_left = geom::Angle(state_.telemetry->front_left_wheel_velocity);
-    wheel_velocity.front_right = geom::Angle(state_.telemetry->front_right_wheel_velocity);
+    const model::WheelVelocity wheel_velocity = {
+        geom::Angle(state_.telemetry->rear_left_wheel_velocity),
+        geom::Angle(state_.telemetry->rear_right_wheel_velocity),
+        geom::Angle(state_.telemetry->front_left_wheel_velocity),
+        geom::Angle(state_.telemetry->front_right_wheel_velocity)};
 
     for (auto wheel : kAllWheels) {
         const double velocity = [&]() {

--- a/packages/visualization/src/visualization_node.cpp
+++ b/packages/visualization/src/visualization_node.cpp
@@ -267,10 +267,8 @@ visualization_msgs::msg::Marker makeMeshMarker(
 void VisualizationNode::updateWheelsSpin() {
     const auto now_seconds = now().seconds();
     const auto time = now_seconds - cache_.last_ego_update_second;
-    const auto rear_twist = model::Twist {
-        state_.telemetry->rear_curvature,
-        state_.telemetry->rear_velocity
-    };
+    const auto rear_twist =
+        model::Twist{state_.telemetry->rear_curvature, state_.telemetry->rear_velocity};
     const auto velocities = model_->rearTwistToWheelVelocity(rear_twist);
     for (auto wheel : kAllWheels) {
         const double velocity = [&]() {
@@ -331,7 +329,7 @@ void VisualizationNode::publishEgo() const {
 
         auto rotation = tf2::Quaternion::getIdentity();
         rotation.setRPY(0, y_angle, z_angle);
-        const auto wheel_tf = 
+        const auto wheel_tf =
             base_to_odom * cache_.wheel_base_tfs[wheel] * tf2::Transform(rotation);
 
         auto wheel_msg = makeMeshMarker(wheel + 1, state_.odom->header, params_.mesh_wheel, color);

--- a/packages/visualization/src/visualization_node.cpp
+++ b/packages/visualization/src/visualization_node.cpp
@@ -267,21 +267,25 @@ visualization_msgs::msg::Marker makeMeshMarker(
 void VisualizationNode::updateWheelsSpin() {
     const auto now_seconds = now().seconds();
     const auto time = now_seconds - cache_.last_ego_update_second;
-    const auto rear_twist =
-        model::Twist{state_.telemetry->rear_curvature, state_.telemetry->rear_velocity};
-    const auto velocities = model_->rearTwistToWheelVelocity(rear_twist);
+
+    const model::WheelVelocity wheel_velocity;
+    wheel_velocity.rear_left = geom::Angle(state_.telemetry->rear_left_wheel_velocity);
+    wheel_velocity.rear_right = geom::Angle(state_.telemetry->rear_right_wheel_velocity);
+    wheel_velocity.front_left = geom::Angle(state_.telemetry->front_left_wheel_velocity);
+    wheel_velocity.front_right = geom::Angle(state_.telemetry->front_right_wheel_velocity);
+
     for (auto wheel : kAllWheels) {
         const double velocity = [&]() {
             switch (wheel) {
                 case WheelIndex::kFrontLeft:
-                    return velocities.front_left.radians();
+                    return wheel_velocity.front_left.radians();
                 case WheelIndex::kFrontRight:
-                    return -velocities.front_right.radians();
+                    return -wheel_velocity.front_right.radians();
                 case WheelIndex::kRearLeft:
-                    return velocities.rear_left.radians();
+                    return wheel_velocity.rear_left.radians();
                 case WheelIndex::kRearRight:
                 default:
-                    return -velocities.rear_right.radians();
+                    return -wheel_velocity.rear_right.radians();
             }
         }();
 

--- a/packages/visualization/src/visualization_node.cpp
+++ b/packages/visualization/src/visualization_node.cpp
@@ -276,14 +276,14 @@ void VisualizationNode::updateWheelsSpin() {
         const double velocity = [&]() {
             switch (wheel) {
                 case WheelIndex::kFrontLeft:
-                    return velocities.left.radians();
+                    return velocities.front_left.radians();
                 case WheelIndex::kFrontRight:
-                    return -velocities.right.radians();
+                    return -velocities.front_right.radians();
                 case WheelIndex::kRearLeft:
-                    return velocities.rear.radians();
+                    return velocities.rear_left.radians();
                 case WheelIndex::kRearRight:
                 default:
-                    return -velocities.rear.radians();
+                    return -velocities.rear_right.radians();
             }
         }();
 

--- a/packages/visualization/src/visualization_node.h
+++ b/packages/visualization/src/visualization_node.h
@@ -107,7 +107,7 @@ class VisualizationNode : public rclcpp::Node {
     struct Cache {
         tf2::Transform body_base_tf;
         std::array<tf2::Transform, 4> wheel_base_tfs;
-        double wheels_spin_angle = 0.0;
+        double wheel_spin_angles[4] = {0.0};
         double last_ego_update_second;
     } cache_;
 

--- a/packages/visualization/src/visualization_node.h
+++ b/packages/visualization/src/visualization_node.h
@@ -22,6 +22,7 @@
 #include <rclcpp/time.hpp>
 
 #include <string>
+#include <optional>
 
 namespace truck::visualization {
 
@@ -107,8 +108,6 @@ class VisualizationNode : public rclcpp::Node {
     struct Cache {
         tf2::Transform body_base_tf;
         std::array<tf2::Transform, 4> wheel_base_tfs;
-        double wheel_spin_angles[4] = {0.0};
-        double last_ego_update_second;
     } cache_;
 
     std::unique_ptr<model::Model> model_ = nullptr;
@@ -124,6 +123,8 @@ class VisualizationNode : public rclcpp::Node {
         truck_msgs::msg::Waypoints::ConstSharedPtr waypoints = nullptr;
         truck_msgs::msg::NavigationMesh::ConstSharedPtr navigation_mesh = nullptr;
         truck_msgs::msg::NavigationRoute::ConstSharedPtr navigation_route = nullptr;
+        double wheel_spin_angles[4] = {0.0};
+        std::optional<double> last_ego_update_seconds = nullptr;
     } state_;
 
     struct Slots {

--- a/packages/visualization/src/visualization_node.h
+++ b/packages/visualization/src/visualization_node.h
@@ -124,7 +124,7 @@ class VisualizationNode : public rclcpp::Node {
         truck_msgs::msg::NavigationMesh::ConstSharedPtr navigation_mesh = nullptr;
         truck_msgs::msg::NavigationRoute::ConstSharedPtr navigation_route = nullptr;
         double wheel_spin_angles[4] = {0.0};
-        std::optional<double> last_ego_update_seconds = nullptr;
+        std::optional<double> last_ego_update_seconds;
     } state_;
 
     struct Slots {

--- a/packages/visualization/src/visualization_node.h
+++ b/packages/visualization/src/visualization_node.h
@@ -35,6 +35,7 @@ class VisualizationNode : public rclcpp::Node {
     void initializeTopicHandlers();
     void initializeCacheBodyBaseTf();
     void initializeCacheWheelBaseTfs();
+    void initializeCache();
 
     void handleTrajectory(truck_msgs::msg::Trajectory::ConstSharedPtr trajectory);
     void handleControl(truck_msgs::msg::Control::ConstSharedPtr control);
@@ -44,6 +45,9 @@ class VisualizationNode : public rclcpp::Node {
     void handleOdometry(nav_msgs::msg::Odometry::ConstSharedPtr msg);
     void handleNavigationMesh(truck_msgs::msg::NavigationMesh::ConstSharedPtr msg);
     void handleNavigationRoute(truck_msgs::msg::NavigationRoute::ConstSharedPtr msg);
+
+    void updateWheelsSpin();
+    void updateEgo();
 
     void publishTrajectory() const;
     void publishEgo() const;
@@ -103,6 +107,8 @@ class VisualizationNode : public rclcpp::Node {
     struct Cache {
         tf2::Transform body_base_tf;
         std::array<tf2::Transform, 4> wheel_base_tfs;
+        double wheels_spin_angle = 0.0;
+        double last_ego_update_second;
     } cache_;
 
     std::unique_ptr<model::Model> model_ = nullptr;


### PR DESCRIPTION
В пакет visualization добавлено вращение маркеров колёс.
Эта реализация вычисляет разные скорости для колёс (как правильно физически).

В сообщение truck::msg::HardwareTelemetry (топик "/hardware/telemetry") добавлены скорости колёс.

В hardware_node дополнено сообщение телеметрии. Скорость вычисляется по RPS двигателя. За кривизну берётся целевое значение из truck::msg::Control. Благодаря этому обновлению в визуализации заработает не только вращение колёс, но и поворот передних.

