### PR TITLE
Simulation collisions

### DIFF
--- a/packages/geom/include/geom/vector.h
+++ b/packages/geom/include/geom/vector.h
@@ -87,6 +87,14 @@ constexpr Vec2 operator*(double c, Vec2 v) noexcept { return v * c; }
 
 constexpr Vec2 operator/(const Vec2& v, double c) noexcept { return {v.x / c, v.y / c}; }
 
+constexpr bool operator<(Vec2 left, Vec2 right) noexcept {
+    if (left.x == right.x) {
+        return true;
+    }
+
+    return left.y < right.y;
+}
+
 constexpr double dot(const Vec2& a, const Vec2& b) noexcept { return a.x * b.x + a.y * b.y; }
 
 constexpr double cross(const Vec2& a, const Vec2& b) noexcept { return a.x * b.y - a.y * b.x; }

--- a/packages/geom/include/geom/vector3.h
+++ b/packages/geom/include/geom/vector3.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <cmath>
+#include <cmath>
+#include <ostream>
+
+namespace truck::geom {
+
+struct Vec3 {
+    constexpr Vec3() : x(0), y(0), z(0) {}
+
+    constexpr Vec3(double x, double y, double z) : x(x), y(y), z(z) {}
+
+    Vec3& operator+=(const Vec3& other) noexcept {
+        x += other.x;
+        y += other.y;
+        z += other.z;
+        return *this;
+    }
+
+    Vec3& operator-=(const Vec3& other) noexcept {
+        x -= other.x;
+        y -= other.y;
+        z -= other.z;
+        return *this;
+    }
+
+    constexpr Vec3 operator+(const Vec3& other) const noexcept {
+        return {x + other.x, y + other.y, z + other.z};
+    }
+
+    constexpr Vec3 operator-(const Vec3& other) const noexcept {
+        return {x - other.x, y - other.y, z - other.z};
+    }
+
+    double lenSq() const noexcept { return x * x + y * y + z * z; }
+
+    double len() const noexcept { return std::hypot(x, y, z); }
+
+    Vec3 unit() const noexcept {
+        const double l = len();
+        return Vec3{x / l, y / l, z / l};
+    }
+
+    static constexpr Vec3 axisX() noexcept { return Vec3{1, 0, 0}; }
+
+    static constexpr Vec3 axisY() noexcept { return Vec3{0, 1, 0}; }
+
+    static constexpr Vec3 axisZ() noexcept { return Vec3{0, 0, 1}; }
+
+    constexpr Vec3 operator-() const noexcept { return inv(); }
+
+    Vec3& operator*=(double c) noexcept {
+        x *= c;
+        y *= c;
+        z *= c;
+        return *this;
+    }
+
+    Vec3& operator/=(double c) noexcept {
+        x /= c;
+        y /= c;
+        z /= c;
+        return *this;
+    }
+
+    constexpr Vec3 inv() const noexcept { return {-x, -y, -z}; }
+
+    double x, y, z;
+};
+
+constexpr Vec3 operator*(Vec3 v, double c) noexcept { 
+    return {v.x * c, v.y * c, v.z * c}; 
+}
+
+constexpr Vec3 operator*(double c, Vec3 v) noexcept { 
+    return v * c; 
+}
+
+constexpr Vec3 operator/(const Vec3& v, double c) noexcept { 
+    return {v.x / c, v.y / c, v.z / c}; 
+}
+
+constexpr double dot(const Vec3& a, const Vec3& b) noexcept { 
+    return a.x * b.x + a.y * b.y + a.z * b.z; 
+}
+
+constexpr Vec3 cross(const Vec3& a, const Vec3& b) noexcept { 
+    return {
+        a.y * b.z - a.z * b.y, 
+        a.z * b.x - a.x * b.z, 
+        a.x * b.y - a.y * b.x
+    }; 
+}
+
+inline double lenSq(const Vec3& v) noexcept { return v.lenSq(); }
+
+inline double len(const Vec3& v) noexcept { return v.len(); }
+
+bool equal(const Vec3& a, const Vec3& b, double eps = 0) noexcept;
+
+Vec3 interpolate(const Vec3& a, const Vec3& b, double t) noexcept;
+
+std::ostream& operator<<(std::ostream& out, const Vec3& v);
+
+}  // namespace truck::geom

--- a/packages/geom/include/geom/vector3.h
+++ b/packages/geom/include/geom/vector3.h
@@ -11,6 +11,10 @@ struct Vec3 {
 
     constexpr Vec3(double x, double y, double z) : x(x), y(y), z(z) {}
 
+    constexpr Vec3(Vec2 vec2, double z) : x(vec2.x), y(vec2.y), z(z) {}
+
+    constexpr Vec3(Vec2 vec2) : Vec3(vec2, 0) {}
+
     Vec3& operator+=(const Vec3& other) noexcept {
         x += other.x;
         y += other.y;

--- a/packages/geom/src/vector3.cpp
+++ b/packages/geom/src/vector3.cpp
@@ -1,0 +1,23 @@
+#include "geom/common.h"
+#include "geom/vector3.h"
+
+#include "common/exception.h"
+
+#include <iomanip>
+
+namespace truck::geom {
+
+bool equal(const Vec3& a, const Vec3& b, double eps) noexcept {
+    return equal(a.x, b.x, eps) && equal(a.y, b.y, eps) && equal(a.z, b.z, eps);
+}
+
+Vec3 interpolate(const Vec3& a, const Vec3& b, double t) noexcept {
+    VERIFY(0 <= t && t <= 1);
+    return a + t * (b - a);
+}
+
+std::ostream& operator<<(std::ostream& out, const Vec3& v) {
+    return out << std::fixed << std::setprecision(3) << "[" << v.x << ", " << v.y << ", " << v.z << "]";
+}
+
+}  // namespace truck::geom

--- a/packages/model/include/model/model.h
+++ b/packages/model/include/model/model.h
@@ -56,6 +56,11 @@ class Model {
     const Wheel& wheel() const;
     const Lidar& lidar() const;
 
+    double rearToArbitraryPointRatio(double rear_curvature,
+      const geom::Vec2& rear_to_point) const;
+    double rearToArbitraryPointCurvature(double rear_curvature,
+      const geom::Vec2& rear_to_point) const;
+    Twist rearToArbitraryPointTwist(Twist twist, const geom::Vec2& rear_to_point) const;
     Twist baseToRearTwist(Twist twist) const;
     Twist rearToBaseTwist(Twist twist) const;
     Steering rearTwistToSteering(Twist twist) const;

--- a/packages/simulator_2d/CMakeLists.txt
+++ b/packages/simulator_2d/CMakeLists.txt
@@ -14,10 +14,12 @@ find_package(rosgraph_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(map REQUIRED)
+find_package(Boost REQUIRED)
 
 add_library(simulator_engine SHARED 
     src/simulator_engine.cpp
-    src/truck_state.cpp)
+    src/truck_state.cpp
+    src/simulator_map.cpp)
 
 ament_target_dependencies(
     simulator_engine

--- a/packages/simulator_2d/CMakeLists.txt
+++ b/packages/simulator_2d/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(model REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(truck_msgs REQUIRED)
 find_package(geom REQUIRED)
+find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_msgs REQUIRED)
 find_package(rosgraph_msgs REQUIRED)
@@ -22,7 +23,8 @@ ament_target_dependencies(
     simulator_engine
     model
     geom
-    map)
+    map
+    tf2)
 
 target_include_directories(
     simulator_engine PUBLIC

--- a/packages/simulator_2d/include/simulator_2d/simulator_engine.h
+++ b/packages/simulator_2d/include/simulator_2d/simulator_engine.h
@@ -76,8 +76,6 @@ class SimulatorEngine {
         double integration_step_6;
         double inverse_integration_step;
         double inverse_wheelbase_length;
-        double shape_length;
-        double shape_width_half;
         geom::Vec2 rear_to_hyro_translation;
         tf2::Transform base_to_hyro_rotation;
     } cache_;

--- a/packages/simulator_2d/include/simulator_2d/simulator_engine.h
+++ b/packages/simulator_2d/include/simulator_2d/simulator_engine.h
@@ -1,10 +1,10 @@
+#include "simulator_2d/simulator_map.h"
 #include "simulator_2d/truck_state.h"
 
 #include "model/model.h"
 #include "geom/angle.h"
 #include "geom/angle_vector.h"
 #include "geom/pose.h"
-#include "geom/segment.h"
 #include "geom/vector.h"
 #include "geom/vector3.h"
 
@@ -44,20 +44,19 @@ class SimulatorEngine {
 
     void initializeParameters(double integration_step, double precision);
     void initializeMathCache(double integration_step);
-    void initializeLidarCache();
     void initializeImuCache();
+    void initializeMap();
 
     void resetRear(double x, double y, double yaw,
         double steering, double linear_velocity);
     void resetRear();
 
-    bool checkForCollisions() const;
+    void checkForCollisions();
 
     geom::Pose getOdomBasePose() const;
     model::Steering getCurrentSteering(double rear_curvature) const;
     model::Steering getTargetSteering() const;
     model::Twist getRearTwist(double rear_curvature) const;
-    std::vector<float> getLidarRanges(const geom::Pose& odom_base_pose) const;
     geom::Vec3 getImuAngularVelocity(double angular_velocity) const;
     geom::Vec3 getImuLinearAcceleration(const model::Twist& rear_twist) const;
 
@@ -77,10 +76,8 @@ class SimulatorEngine {
         double integration_step_6;
         double inverse_integration_step;
         double inverse_wheelbase_length;
-        geom::Vec2 base_to_lidar;
-        int lidar_rays_number;
-        geom::AngleVec2 lidar_angle_min;
-        geom::Angle lidar_angle_increment;
+        double shape_length;
+        double shape_width_half;
         geom::Vec2 rear_to_hyro_translation;
         tf2::Transform base_to_hyro_rotation;
     } cache_;
@@ -100,7 +97,7 @@ class SimulatorEngine {
 
     std::unique_ptr<model::Model> model_ = nullptr;
 
-    geom::Segments obstacles_;
+    std::unique_ptr<SimulatorMap> map_ = nullptr;
 };
 
 }  // namespace truck::simulator

--- a/packages/simulator_2d/include/simulator_2d/simulator_engine.h
+++ b/packages/simulator_2d/include/simulator_2d/simulator_engine.h
@@ -6,6 +6,7 @@
 #include "geom/pose.h"
 #include "geom/segment.h"
 #include "geom/vector.h"
+#include "geom/vector3.h"
 
 #include <Eigen/Dense>
 
@@ -41,6 +42,11 @@ class SimulatorEngine {
 
     using State = Eigen::Matrix<double, 5, 1>;
 
+    void initializeParameters(double integration_step, double precision);
+    void initializeMathCache(double integration_step);
+    void initializeLidarCache();
+    void initializeImuCache();
+
     void resetRear(double x, double y, double yaw,
         double steering, double linear_velocity);
     void resetRear();
@@ -48,12 +54,10 @@ class SimulatorEngine {
     geom::Pose getOdomBasePose() const;
     model::Steering getCurrentSteering(double rear_curvature) const;
     model::Steering getTargetSteering() const;
-    model::Twist rearToOdomBaseTwist(double rear_curvature) const;
-    geom::Vec2 rearToOdomBaseLinearVelocity(
-        truck::geom::AngleVec2 dir,double base_velocity) const;
-    double rearToBaseAngularVelocity(
-        double base_velocity, double rear_curvature) const;
+    model::Twist getRearTwist(double rear_curvature) const;
     std::vector<float> getLidarRanges(const geom::Pose& odom_base_pose) const;
+    geom::Vec3 getImuAngularVelocity(double angular_velocity) const;
+    geom::Vec3 getImuLinearAcceleration(const model::Twist& rear_twist) const;
 
     double getCurrentAcceleration() const;
     double getCurrentSteeringVelocity() const;
@@ -75,6 +79,8 @@ class SimulatorEngine {
         int lidar_rays_number;
         geom::AngleVec2 lidar_angle_min;
         geom::Angle lidar_angle_increment;
+        geom::Vec2 rear_to_hyro_translation;
+        tf2::Transform base_to_hyro_rotation;
     } cache_;
 
     // The value is set in setControl and should not change in other methods.

--- a/packages/simulator_2d/include/simulator_2d/simulator_engine.h
+++ b/packages/simulator_2d/include/simulator_2d/simulator_engine.h
@@ -51,6 +51,8 @@ class SimulatorEngine {
         double steering, double linear_velocity);
     void resetRear();
 
+    bool checkForCollisions() const;
+
     geom::Pose getOdomBasePose() const;
     model::Steering getCurrentSteering(double rear_curvature) const;
     model::Steering getTargetSteering() const;
@@ -89,6 +91,8 @@ class SimulatorEngine {
         std::optional<double> acceleration = 0.0;
         double curvature = 0.0;
     } control_;
+
+    bool fail_ = false;
 
     rclcpp::Time time_;
 

--- a/packages/simulator_2d/include/simulator_2d/simulator_map.h
+++ b/packages/simulator_2d/include/simulator_2d/simulator_map.h
@@ -3,32 +3,51 @@
 #include "geom/segment.h"
 #include "geom/vector.h"
 
+#include <boost/geometry.hpp>
+
 #include <string>
 #include <vector>
 
 namespace truck::simulator {
 
+namespace bg = boost::geometry;
+namespace bgi = boost::geometry::index;
+
+using RTreePoint = bg::model::point<double, 2, bg::cs::cartesian>;
+using RTreeSegment = bg::model::segment<RTreePoint>;
+using RTreeBox = bg::model::box<RTreePoint>;
+using RTreeIndexedSegment = std::pair<RTreeSegment, size_t>;
+using RTreeIndexedSegments = std::vector<RTreeIndexedSegment>;
+using RTree = bgi::rtree<RTreeIndexedSegment, bgi::rstar<16>>;
+
 class SimulatorMap {
   public:
     SimulatorMap(double precision, const geom::Vec2& base_to_lidar,
-      const model::Lidar& lidar_config);
+      const model::Lidar& lidar, const model::Shape& shape);
 
     void resetMap(const std::string& path);
     void eraseMap();
-    bool checkForCollisions(const geom::Vec2& rear_ax_center,
-      double length, double width_half, double yaw) const;
+    bool checkForCollisions(const geom::Vec2& rear_ax_center, double yaw) const;
     std::vector<float> getLidarRanges(const geom::Pose& odom_base_pose) const;
 
   private:
+    void initializeLidarParams(const geom::Vec2& base_to_lidar,
+      const model::Lidar& lidar);
+    void initializeShapeParams(const model::Shape& shape);
+    void initializeRTree();
+
     struct Parameters {
         double precision;
         geom::Vec2 base_to_lidar;
         int lidar_rays_number;
         geom::AngleVec2 lidar_angle_min;
         geom::Angle lidar_angle_increment;
+        double shape_length;
+        double shape_width_half;
     } params_;
 
     geom::Segments obstacles_;
+    RTree rtree_;
 };
 
 }  // namespace truck::simulator

--- a/packages/simulator_2d/include/simulator_2d/simulator_map.h
+++ b/packages/simulator_2d/include/simulator_2d/simulator_map.h
@@ -43,8 +43,13 @@ class SimulatorMap {
         geom::AngleVec2 lidar_angle_min;
         geom::Angle lidar_angle_increment;
         double shape_length;
-        double shape_width_half;
     } params_;
+
+    struct Cache {
+        double shape_length_half;
+        double shape_width_half;
+        double box_radius;
+    } cache_;
 
     geom::Segments obstacles_;
     RTree rtree_;

--- a/packages/simulator_2d/include/simulator_2d/simulator_map.h
+++ b/packages/simulator_2d/include/simulator_2d/simulator_map.h
@@ -1,0 +1,34 @@
+#include "model/model.h"
+#include "geom/pose.h"
+#include "geom/segment.h"
+#include "geom/vector.h"
+
+#include <string>
+#include <vector>
+
+namespace truck::simulator {
+
+class SimulatorMap {
+  public:
+    SimulatorMap(double precision, const geom::Vec2& base_to_lidar,
+      const model::Lidar& lidar_config);
+
+    void resetMap(const std::string& path);
+    void eraseMap();
+    bool checkForCollisions(const geom::Vec2& rear_ax_center,
+      double length, double width_half, double yaw) const;
+    std::vector<float> getLidarRanges(const geom::Pose& odom_base_pose) const;
+
+  private:
+    struct Parameters {
+        double precision;
+        geom::Vec2 base_to_lidar;
+        int lidar_rays_number;
+        geom::AngleVec2 lidar_angle_min;
+        geom::Angle lidar_angle_increment;
+    } params_;
+
+    geom::Segments obstacles_;
+};
+
+}  // namespace truck::simulator

--- a/packages/simulator_2d/include/simulator_2d/truck_state.h
+++ b/packages/simulator_2d/include/simulator_2d/truck_state.h
@@ -10,7 +10,7 @@ namespace truck::simulator {
 
 class TruckState {
   public:
-    bool fail const;
+    bool fail() const;
     rclcpp::Time time() const;
     geom::Pose odomBasePose() const;
     model::Steering currentSteering() const;

--- a/packages/simulator_2d/include/simulator_2d/truck_state.h
+++ b/packages/simulator_2d/include/simulator_2d/truck_state.h
@@ -10,6 +10,7 @@ namespace truck::simulator {
 
 class TruckState {
   public:
+    bool fail const;
     rclcpp::Time time() const;
     geom::Pose odomBasePose() const;
     model::Steering currentSteering() const;
@@ -23,6 +24,7 @@ class TruckState {
     geom::Vec3 gyroAngularVelocity() const;
     geom::Vec3 accelLinearAcceleration() const;
 
+    TruckState& fail(bool fail);
     TruckState& time(const rclcpp::Time& time);
     TruckState& odomBasePose(const geom::Pose& pose);
     TruckState& currentSteering(const model::Steering& current_steering);
@@ -38,6 +40,7 @@ class TruckState {
 
   private:
     struct Cache {
+        bool fail;
         rclcpp::Time time;
         geom::Pose base_odom_pose;
         model::Steering current_steering;

--- a/packages/simulator_2d/include/simulator_2d/truck_state.h
+++ b/packages/simulator_2d/include/simulator_2d/truck_state.h
@@ -2,6 +2,7 @@
 #include "geom/angle.h"
 #include "geom/pose.h"
 #include "geom/vector.h"
+#include "geom/vector3.h"
 
 #include <vector>
 
@@ -19,6 +20,8 @@ class TruckState {
     const std::vector<float>& lidarRanges() const;
     double currentMotorRps() const;
     double targetMotorRps() const;
+    geom::Vec3 gyroAngularVelocity() const;
+    geom::Vec3 accelLinearAcceleration() const;
 
     TruckState& time(const rclcpp::Time& time);
     TruckState& odomBasePose(const geom::Pose& pose);
@@ -30,6 +33,8 @@ class TruckState {
     TruckState& lidarRanges(std::vector<float> lidar_ranges);
     TruckState& currentMotorRps(double current_rps);
     TruckState& targetMotorRps(double target_rps);
+    TruckState& gyroAngularVelocity(geom::Vec3 angular_velocity);
+    TruckState& accelLinearAcceleration(geom::Vec3 linear_acceleration);
 
   private:
     struct Cache {
@@ -43,6 +48,8 @@ class TruckState {
         std::vector<float> lidar_ranges;
         double current_motor_rps;
         double target_motor_rps;
+        geom::Vec3 gyro_angular_velocity;
+        geom::Vec3 accel_linear_acceleration;
     } cache_;
 };
 

--- a/packages/simulator_2d/package.xml
+++ b/packages/simulator_2d/package.xml
@@ -21,6 +21,7 @@
   <depend>nlohmann_json</depend>
   <depend>map</depend>
   <depend>sensor_msgs</depend>
+  <depend>Boost</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/packages/simulator_2d/src/simulator_engine.cpp
+++ b/packages/simulator_2d/src/simulator_engine.cpp
@@ -186,7 +186,7 @@ TruckState SimulatorEngine::getTruckState() const {
     const auto twist = model_->rearToBaseTwist(rear_twist);
     const auto linear_velocity = rearToOdomBaseLinearVelocity(pose.dir, twist.velocity);
     const auto angular_velocity = getAngularVelocity(twist);
-    auto lidar_ranges = map_.getLidarRanges(pose);
+    auto lidar_ranges = map_->getLidarRanges(pose);
     const auto current_rps = model_->linearVelocityToMotorRPS(twist.velocity);
     const auto target_rps = model_->linearVelocityToMotorRPS(control_.velocity);
     const auto gyro_angular_velocity = getImuAngularVelocity(angular_velocity);

--- a/packages/simulator_2d/src/simulator_engine.cpp
+++ b/packages/simulator_2d/src/simulator_engine.cpp
@@ -107,6 +107,12 @@ void SimulatorEngine::eraseMap() {
     obstacles_.clear();
 }
 
+bool SimulatorEngine::checkForCollisions() const {
+    const var intersection = geom::intersect(a, b, params_.precision);
+
+    return false;
+}
+
 geom::Pose SimulatorEngine::getOdomBasePose() const {
     const double x = rear_ax_state_[StateIndex::kX];
     const double y = rear_ax_state_[StateIndex::kY];
@@ -511,6 +517,10 @@ rclcpp::Duration convertFromSecondsToDuration(double seconds) {
 } // namespace
 
 void SimulatorEngine::advance(double seconds) {
+    if (fail_) {
+        return;
+    }
+
     time_ += convertFromSecondsToDuration(seconds);
 
     const int integration_steps = seconds * cache_.inverse_integration_step;

--- a/packages/simulator_2d/src/simulator_engine.cpp
+++ b/packages/simulator_2d/src/simulator_engine.cpp
@@ -34,8 +34,6 @@ void SimulatorEngine::initializeMathCache(double integration_step) {
     cache_.integration_step_6 = integration_step / 6;
     cache_.inverse_integration_step = 1 / integration_step;
     cache_.inverse_wheelbase_length = 1 / model_->wheelBase().length;
-    cache_.shape_length = model_->shape().length;
-    cache_.shape_width_half = model_->shape().width / 2;
 }
 
 void SimulatorEngine::initializeImuCache() {
@@ -49,7 +47,8 @@ void SimulatorEngine::initializeImuCache() {
 void SimulatorEngine::initializeMap() {
     const auto lidar_translation = model_->getLatestTranform("base", "lidar_link").getOrigin();
     const geom::Vec2 base_to_lidar(lidar_translation.x(), lidar_translation.y());
-    map_ = std::make_unique<SimulatorMap>(params_.precision, base_to_lidar, model_->lidar());
+    map_ = std::make_unique<SimulatorMap>(params_.precision,
+        base_to_lidar, model_->lidar(), model_->shape());
 }
 
 void SimulatorEngine::resetRear(double x, double y, double yaw,
@@ -94,7 +93,7 @@ void SimulatorEngine::checkForCollisions() {
     const double y = rear_ax_state_[StateIndex::kY];
     const double yaw = rear_ax_state_[StateIndex::kYaw];
 
-    fail_ |= map_->checkForCollisions({x, y}, cache_.shape_length, cache_.shape_width_half, yaw);
+    fail_ = map_->checkForCollisions({x, y}, yaw);
 }
 
 geom::Pose SimulatorEngine::getOdomBasePose() const {

--- a/packages/simulator_2d/src/simulator_map.cpp
+++ b/packages/simulator_2d/src/simulator_map.cpp
@@ -1,0 +1,190 @@
+#include "simulator_2d/simulator_map.h"
+
+#include "map/map.h"
+#include "geom/distance.h"
+#include "geom/intersection.h"
+
+#include <boost/geometry.hpp>
+
+#include <cmath>
+#include <limits>
+
+namespace truck::simulator {
+
+namespace bg = boost::geometry;
+namespace bgi = boost::geometry::index;
+
+using RTreePoint = bg::model::point<double, 2, bg::cs::cartesian>;
+using RTreeSegment = bg::model::segment<RTreePoint>;
+using RTreeBox = bg::model::box<RTreePoint>;
+using RTreeIndexedPoint = std::pair<RTreeSegment, size_t>;
+using RTreeIndexedPoints = std::vector<RTreeIndexedPoint>;
+using RTree = bgi::rtree<RTreeIndexedPoint, bgi::rstar<16>>;
+
+SimulatorMap::SimulatorMap(double precision, const geom::Vec2& base_to_lidar,
+    const model::Lidar& lidar_config) {
+
+    params_.precision = precision;
+    initializeLidarParams(base_to_lidar, lidar_config);
+}
+
+void SimulatorMap::initializeLidarParams(const geom::Vec2& base_to_lidar,
+    const model::Lidar& lidar_config) {
+
+    params_.base_to_lidar = base_to_lidar;
+
+    const double angle_min_rad = lidar_config.angle_min.radians();
+    const double angle_max_rad = lidar_config.angle_max.radians();
+    const double angle_increment_rad = lidar_config.angle_increment.radians();
+
+    params_.lidar_rays_number = (angle_max_rad - angle_min_rad) / angle_increment_rad;
+    params_.lidar_angle_min = geom::AngleVec2(lidar_config.angle_min);
+    params_.lidar_angle_increment = lidar_config.angle_increment;
+}
+
+void SimulatorMap::resetMap(const std::string& path) {
+    obstacles_.clear();
+    const auto map = map::Map::fromGeoJson(path);
+    const auto polygons = map.polygons();
+    for (const auto &polygon: polygons) {
+        auto segments = polygon.segments();
+        obstacles_.insert(obstacles_.end(), 
+            std::make_move_iterator(segments.begin()), 
+            std::make_move_iterator(segments.end()));
+    }
+}
+
+void SimulatorMap::eraseMap() {
+    obstacles_.clear();
+}
+
+namespace {
+
+geom::Polygon getBounds(const geom::Vec2& rear_ax_center,
+    double length, double width_half, double yaw) {
+
+    const auto yaw_vec = geom::Vec2::fromAngle(geom::Angle::fromRadians(yaw));
+    const auto dir = length * yaw_vec;
+    const auto norm = width_half * yaw_vec;
+    const geom::Vec2 a(rear_ax_center.x - norm.y, rear_ax_center.y + norm.x);
+    const geom::Vec2 b(rear_ax_center.x + norm.y, rear_ax_center.y - norm.x);
+    return {a, b, a + dir, b + dir};
+}
+
+} // namespace
+
+void SimulatorMap::checkForCollisions(const geom::Vec2& rear_ax_center,
+    double length, double width_half, double yaw) {
+
+    const geom::Polygon bounds = getBounds(rear_ax_center, length, width_half, yaw);
+    for (const auto& segment : obstacles_) {
+        if (geom::intersect(bounds, segment, params_.precision)) {
+            fail_ = true;
+            return;
+        }
+    }
+}
+
+namespace {
+
+int mod(int number, int divider) {
+    return (number % divider + divider) % divider;
+}
+
+geom::Vec2 getLidarOrigin(const geom::Pose& odom_base_pose, const geom::Vec2& from_base) {
+    const auto dir_vec = odom_base_pose.dir.vec();
+    const auto x = odom_base_pose.pos.x 
+        + from_base.x * dir_vec.x - from_base.y * dir_vec.y;
+    const auto y = odom_base_pose.pos.y
+        + from_base.y * dir_vec.x + from_base.x * dir_vec.y;
+    return geom::Vec2(x, y);
+}
+
+geom::Angle getOrientedAngle(const geom::Vec2& origin_to_point, 
+    const geom::Vec2& dir) {
+
+    auto origin_to_point_angle = geom::angleBetween(dir, origin_to_point);
+    return origin_to_point_angle._0_2PI();
+}
+
+double ceilWithPrecision(double number, double precision) {
+    return std::ceil(number / precision) * precision;
+}
+
+geom::AngleVec2 getRayDir(const geom::AngleVec2& zero_dir, 
+    const geom::Angle increment, const int index) {
+    
+    const auto mult_increment = geom::AngleVec2(index * increment);
+    return zero_dir + mult_increment;
+}
+
+float getIntersectionDistance(const geom::Ray& ray, 
+    const geom::Segment& segment, double precision) {
+
+    const auto intersection = geom::intersect(ray, segment, precision);
+    if (!intersection) {
+        return std::numeric_limits<float>::max();
+    }
+
+    const auto distance = geom::distance(*intersection, ray.origin);
+    return static_cast<float>(distance);
+}
+
+} // namespace
+
+std::vector<float> SimulatorMap::getLidarRanges(const geom::Pose& odom_base_pose) const {
+    std::vector<float> ranges(params_.lidar_rays_number, std::numeric_limits<float>::max());
+    
+    const auto origin = getLidarOrigin(odom_base_pose, params_.base_to_lidar);
+    const auto dir = (odom_base_pose.dir + params_.lidar_angle_min);
+    const auto dir_vector = dir.vec();
+    const auto increment_rad = params_.lidar_angle_increment.radians();
+
+    for (const auto& segment : obstacles_) {
+        const auto origin_begin = segment.begin - origin;
+        const auto origin_end = segment.end - origin;
+
+        auto begin_oriented_angle = getOrientedAngle(origin_begin, dir_vector);
+        auto end_oriented_angle = getOrientedAngle(origin_end, dir_vector);
+
+        const int sign = geom::angleBetween(origin_begin, origin_end).radians() > 0
+            ? 1 : -1;
+        int begin_index, end_index;
+
+        if (sign > 0) {
+            begin_index = ceilWithPrecision(
+                begin_oriented_angle.radians() / increment_rad, 
+                params_.precision);
+            end_index = end_oriented_angle.radians() / increment_rad;
+        } else {
+            begin_index = begin_oriented_angle.radians() / increment_rad;
+            end_index = ceilWithPrecision(
+                end_oriented_angle.radians() / increment_rad, 
+                params_.precision);
+        }
+
+        if (begin_index >= params_.lidar_rays_number
+            && end_index >= params_.lidar_rays_number) {
+            continue;
+        }
+
+        begin_index = std::min(begin_index, params_.lidar_rays_number - 1);
+        end_index = std::min(end_index, params_.lidar_rays_number - 1);
+
+        geom::Ray current_ray(origin, 
+            getRayDir(dir, params_.lidar_angle_increment, begin_index));
+        const auto increment = geom::AngleVec2(sign * params_.lidar_angle_increment);
+        int index = begin_index - sign;
+        
+        do {
+            index = mod(index + sign, params_.lidar_rays_number);
+            const auto distance = getIntersectionDistance(current_ray, segment, params_.precision);
+            ranges[index] = std::min(ranges[index], distance);
+            current_ray.dir += increment;
+        } while (index != end_index);
+    }
+
+    return ranges;
+}
+
+}  // namespace truck::simulator

--- a/packages/simulator_2d/src/simulator_map.cpp
+++ b/packages/simulator_2d/src/simulator_map.cpp
@@ -109,12 +109,12 @@ bool SimulatorMap::checkForCollisions(const geom::Vec2& rear_ax_center, double y
     for (const auto& rtreeSegment : result) {
         const geom::Segment segment(
             {
-                bg::get<0, 0>(rtreeSegment),
-                bg::get<0, 1>(rtreeSegment)
+                bg::get<0, 0>(rtreeSegment.first),
+                bg::get<0, 1>(rtreeSegment.first)
             }, 
             {
-                bg::get<1, 0>(rtreeSegment),
-                bg::get<1, 1>(rtreeSegment)
+                bg::get<1, 0>(rtreeSegment.first),
+                bg::get<1, 1>(rtreeSegment.first)
             });
 
         if (geom::intersect(bounds, segment, params_.precision)) {

--- a/packages/simulator_2d/src/simulator_node.cpp
+++ b/packages/simulator_2d/src/simulator_node.cpp
@@ -178,6 +178,7 @@ void SimulatorNode::publishSimulationStateMessage(const TruckState& truck_state)
     state_msg.header.stamp = truck_state.time();
     state_msg.speed = truck_state.baseTwist().velocity;
     state_msg.steering = truck_state.currentSteering().middle.radians();
+    state_msg.fail = truck_state.fail();
     signals_.state->publish(state_msg);
 }
 

--- a/packages/simulator_2d/src/simulator_node.cpp
+++ b/packages/simulator_2d/src/simulator_node.cpp
@@ -201,8 +201,7 @@ void SimulatorNode::publishImuMessage(const TruckState& truck_state) {
     imu_msg.header.stamp = truck_state.time();
 
     // Set the sensor orientation.
-    const auto pose = truck_state.odomBasePose();
-    imu_msg.orientation = truck::geom::msg::toQuaternion(pose.dir);
+    imu_msg.orientation.covariance[0] = -1;
 
     // Set the gyroscope.
     const auto angular_velocity = truck_state.gyroAngularVelocity();

--- a/packages/simulator_2d/src/simulator_node.cpp
+++ b/packages/simulator_2d/src/simulator_node.cpp
@@ -197,11 +197,11 @@ void SimulatorNode::publishLaserScanMessage(const TruckState& truck_state) {
 
 void SimulatorNode::publishImuMessage(const TruckState& truck_state) {
     sensor_msgs::msg::Imu imu_msg;
-    imu_msg.header.frame_id = "camera_link";
+    imu_msg.header.frame_id = "camera_imu_optical_frame";
     imu_msg.header.stamp = truck_state.time();
 
     // Set the sensor orientation.
-    imu_msg.orientation.covariance[0] = -1;
+    imu_msg.orientation_covariance[0] = -1;
 
     // Set the gyroscope.
     const auto angular_velocity = truck_state.gyroAngularVelocity();

--- a/packages/simulator_2d/src/simulator_node.h
+++ b/packages/simulator_2d/src/simulator_node.h
@@ -10,6 +10,7 @@
 #include <tf2_msgs/msg/tf_message.hpp>
 #include <rosgraph_msgs/msg/clock.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
+#include <sensor_msgs/msg/imu.hpp>
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -35,6 +36,7 @@ class SimulatorNode : public rclcpp::Node {
     void publishTelemetryMessage(const TruckState& truck_state);
     void publishSimulationStateMessage(const TruckState& truck_state);
     void publishLaserScanMessage(const TruckState& truck_state);
+    void publishImuMessage(const TruckState& truck_state);
     void publishSimulationState();
 
     void makeSimulationTick();
@@ -70,6 +72,7 @@ class SimulatorNode : public rclcpp::Node {
         rclcpp::Publisher<truck_msgs::msg::HardwareTelemetry>::SharedPtr telemetry = nullptr;
         rclcpp::Publisher<truck_msgs::msg::SimulationState>::SharedPtr state = nullptr;
         rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr scan = nullptr;
+        rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu = nullptr;
     } signals_;
 };
 

--- a/packages/simulator_2d/src/truck_state.cpp
+++ b/packages/simulator_2d/src/truck_state.cpp
@@ -45,6 +45,14 @@ double TruckState::targetMotorRps() const {
     return cache_.target_motor_rps;
 }
 
+geom::Vec3 TruckState::gyroAngularVelocity() const {
+    return cache_.gyro_angular_velocity;
+}
+
+geom::Vec3 TruckState::accelLinearAcceleration() const {
+    return cache_.accel_linear_acceleration;
+}
+
 TruckState& TruckState::time(const rclcpp::Time& time) {
     cache_.time = time;
     return *this;
@@ -92,6 +100,16 @@ TruckState& TruckState::currentMotorRps(double current_rps) {
 
 TruckState& TruckState::targetMotorRps(double target_rps) {
     cache_.target_motor_rps = target_rps;
+    return *this;
+}
+
+TruckState& TruckState::gyroAngularVelocity(geom::Vec3 angular_velocity) {
+    cache_.gyro_angular_velocity = angular_velocity;
+    return *this;
+}
+
+TruckState& TruckState::accelLinearAcceleration(geom::Vec3 linear_acceleration) {
+    cache_.accel_linear_acceleration = linear_acceleration;
     return *this;
 }
 

--- a/packages/simulator_2d/src/truck_state.cpp
+++ b/packages/simulator_2d/src/truck_state.cpp
@@ -5,6 +5,10 @@
 
 namespace truck::simulator {
 
+bool TruckState::fail() const {
+    return cache_.fail;
+}
+
 rclcpp::Time TruckState::time() const {
     return cache_.time;
 }
@@ -51,6 +55,11 @@ geom::Vec3 TruckState::gyroAngularVelocity() const {
 
 geom::Vec3 TruckState::accelLinearAcceleration() const {
     return cache_.accel_linear_acceleration;
+}
+
+TruckState& TruckState::fail(bool fail) {
+    cache_.fail = fail;
+    return *this;
 }
 
 TruckState& TruckState::time(const rclcpp::Time& time) {

--- a/packages/truck_msgs/msg/SimulationState.msg
+++ b/packages/truck_msgs/msg/SimulationState.msg
@@ -2,3 +2,4 @@ std_msgs/Header header
 
 float64 speed
 float64 steering
+bool fail


### PR DESCRIPTION
Декомпозировал движок симуляции, вынес в SimulatorMap всё, что связано с вычислениями карты. Сейчас это лидарное облако и коллизии.
Добавлен поиск коллизий трака (точнее, коробочки - shape) с препятствиями (отрезками).
Поиск коллизий оптимизирован с помощью RTree из библиотеки Boost.
Поскольку поиск по RTree неточный, беру ближайшие отрезки по радиусу с запасом, после чего проверяю каждый с помощью geom::intersect.
Симуляция прерывается при коллизии. Флаг fail_ устанавливается в true, движок симулятора перестаёт реагировать на вызов advance. Для откладки добавлено поле в SimulationState.msg.