### PR TITLE
feat: auto-completion for colcon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -597,9 +597,8 @@ RUN printf "export CC='${CC}'\n" >> /root/.bashrc \
     && printf "export RCUTILS_CONSOLE_OUTPUT_FORMAT='[{severity}:{time}] {message}'\n" >> /root/.bashrc \
     && printf "export TRUCK_SIMULATION=false\n" >> /root/.bashrc \
     && printf "export TRUCK_CONTROL=ipega\n" >> /root/.bashrc \
+    && printf "source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash\n" >> /root/.bashrc \
     && ln -sf /usr/bin/clang-format-${CLANG_VERSION} /usr/bin/clang-format
-
-RUN source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash
 
 ### SETUP ENTRYPOINT
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -599,6 +599,8 @@ RUN printf "export CC='${CC}'\n" >> /root/.bashrc \
     && printf "export TRUCK_CONTROL=ipega\n" >> /root/.bashrc \
     && ln -sf /usr/bin/clang-format-${CLANG_VERSION} /usr/bin/clang-format
 
+RUN source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash
+
 ### SETUP ENTRYPOINT
 
 WORKDIR /truck


### PR DESCRIPTION
Из "коробки" в контейнере нету автокомплита для комманд colcon'а, решил добавить, а то не удобно: https://colcon.readthedocs.io/en/released/user/installation.html#enable-completion