### PR TITLE
feat: integrate A* algorithm in the navigation node

### DIFF
--- a/packages/navigation/include/navigation/search.h
+++ b/packages/navigation/include/navigation/search.h
@@ -5,9 +5,6 @@
 #include "geom/polyline.h"
 #include "common/exception.h"
 
-#include <set>
-#include <optional>
-
 namespace truck::navigation::search {
 
 struct Path {

--- a/packages/navigation/test/main.cpp
+++ b/packages/navigation/test/main.cpp
@@ -69,7 +69,7 @@ TEST(Navigation, graph) {
     const graph::GraphBuilder graph_builder = graph::GraphBuilder(graph_params);
     const graph::Graph graph = graph_builder.build(mesh_build.mesh, polygons);
 
-    const geom::Polyline path = search::toPolyline(graph, search::findShortestPath(graph, 28, 306));
+    const geom::Polyline path = search::toPolyline(graph, search::findShortestPath(graph, 28, 148));
 
     VERIFY(polygons.size() == 1);
     const auto& polygon = polygons[0];


### PR DESCRIPTION
Обновил алгоритм дейкстры в модуле поиска пути до А*. Используемая эвристика - `geom::distance`. 

Я думал над какой-то оптимизацией постоянных вычислений функции `sqrt`  при этом, но, честно говоря, я в этом особо не вижу смысла, т.к. во-первых, использовать другую эвристику будет в принципе нецелесообразно, во-вторых за время работы над проектом я понял, что "у нас нет проблем с производительностью" 😁. 

Ну а вообще, конечно, я могу сделать мемоизацию, если все-таки это будет иметь смысл.