### PR TITLE
LiDAR map (serializer for .pcd format) 

### DIFF
--- a/packages/lidar_map/CMakeLists.txt
+++ b/packages/lidar_map/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(rosbag2_cpp REQUIRED)
 find_package(libpointmatcher REQUIRED)
 find_package(map REQUIRED)
 find_package(G2O REQUIRED)
+find_package(PCL REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(visualization REQUIRED)
 find_package(
@@ -43,11 +44,13 @@ ament_target_dependencies(
   rosbag2_cpp
   libpointmatcher
   G2O
+  PCL
   visualization
   Boost
 )
 
 target_link_libraries(${PROJECT_NAME} ${G2O_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES})
 
 target_include_directories(
   ${PROJECT_NAME}
@@ -66,6 +69,7 @@ ament_export_dependencies(
   rosbag2_cpp
   libpointmatcher
   G2O
+  PCL
   visualization
   Boost
 )

--- a/packages/lidar_map/include/lidar_map/serialization.h
+++ b/packages/lidar_map/include/lidar_map/serialization.h
@@ -26,4 +26,8 @@ void writeToMCAP(
     const std::string& mcap_path, const Cloud& cloud, const std::string& cloud_topic_name,
     const geom::ComplexPolygon& map, const std::string& map_topic_name);
 
+Cloud loadPCD(const std::string& pcd_path);
+
+void writeToPCD(const std::string& pcd_path, const Cloud& cloud);
+
 }  // namespace truck::lidar_map

--- a/packages/lidar_map/package.xml
+++ b/packages/lidar_map/package.xml
@@ -18,6 +18,7 @@
   <depend>libpointmatcher</depend>
   <depend>map</depend>
   <depend>G2O</depend>
+  <depend>PCL</depend>
   <depend>ament_index_cpp</depend>
   <depend>visualization</depend>
   <depend>Boost</depend>


### PR DESCRIPTION
Добавил возможность сериализации и десериализации лидарной карты в `.pcd` формат. Карты в этом формате могут быть визуализированы с помощью VS Code Extensions, что позволяет быстро оценить качество построенной карты без необходимости открывать `.mcap` бэг в Foxglove Studio.