### PR TITLE
Fixes to map builder tool

### DIFF
--- a/packages/lidar_map/CMakeLists.txt
+++ b/packages/lidar_map/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(map REQUIRED)
 find_package(G2O REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(visualization REQUIRED)
+find_package(tools REQUIRED)
 find_package(
   Boost
   COMPONENTS thread
@@ -44,6 +45,7 @@ ament_target_dependencies(
   libpointmatcher
   G2O
   visualization
+  tools
   Boost
 )
 
@@ -67,6 +69,7 @@ ament_export_dependencies(
   libpointmatcher
   G2O
   visualization
+  tools
   Boost
 )
 
@@ -91,6 +94,7 @@ ament_target_dependencies(
   nav_msgs
   sensor_msgs
   ament_index_cpp
+  tools
   Boost
 )
 

--- a/packages/lidar_map/config/icp.yaml
+++ b/packages/lidar_map/config/icp.yaml
@@ -33,4 +33,4 @@ inspector:
    NullInspector
 
 logger:
-   FileLogger
+  NullLogger

--- a/packages/lidar_map/include/lidar_map/builder.h
+++ b/packages/lidar_map/include/lidar_map/builder.h
@@ -10,7 +10,6 @@ struct BuilderParams {
     std::string icp_config;
 
     double icp_edge_max_dist = 0.6;
-    double poses_min_dist = 0.5;
 
     double odom_edge_weight = 1.0;
     double icp_edge_weight = 3.0;
@@ -25,13 +24,19 @@ class Builder {
     Builder(const BuilderParams& params);
 
     std::pair<geom::Poses, Clouds> filterByPosesProximity(
-        const geom::Poses& poses, const Clouds& clouds) const;
+        const geom::Poses& poses, const Clouds& clouds, double poses_min_dist) const;
 
     geom::Poses optimizePoses(const geom::Poses& poses, const Clouds& clouds);
 
     Clouds transformClouds(const geom::Poses& poses, const Clouds& clouds) const;
 
     Cloud mergeClouds(const Clouds& clouds) const;
+
+    Cloud mergeCloudsByPointsSimilarity(
+        const Clouds& clouds, int sim_points_min_count, double sim_points_max_dist,
+        int clouds_range = -1) const;
+
+    Clouds applyGridFilter(const Clouds& clouds, double cell_size) const;
 
   private:
     ICP icp_;

--- a/packages/lidar_map/include/lidar_map/builder.h
+++ b/packages/lidar_map/include/lidar_map/builder.h
@@ -4,6 +4,8 @@
 
 #include "geom/pose.h"
 
+#include <vector>
+
 namespace truck::lidar_map {
 
 struct BuilderParams {
@@ -33,12 +35,15 @@ class Builder {
     Cloud mergeClouds(const Clouds& clouds) const;
 
     Cloud mergeCloudsByPointsSimilarity(
-        const Clouds& clouds, int sim_points_min_count, double sim_points_max_dist,
-        int clouds_range = -1) const;
+        const geom::Poses& poses, const Clouds& clouds, int sim_points_min_count,
+        double sim_points_max_dist, int clouds_range = -1) const;
 
     Clouds applyGridFilter(const Clouds& clouds, double cell_size) const;
 
   private:
+    std::vector<std::vector<size_t>> nearestPosesToEachPose(
+        const geom::Poses& poses, double poses_max_dist, uint32_t poses_max_num) const;
+
     ICP icp_;
 
     BuilderParams params_;

--- a/packages/lidar_map/package.xml
+++ b/packages/lidar_map/package.xml
@@ -20,6 +20,7 @@
   <depend>G2O</depend>
   <depend>ament_index_cpp</depend>
   <depend>visualization</depend>
+  <depend>tools</depend>
   <depend>Boost</depend>
 
   <export>

--- a/packages/lidar_map/src/main.cpp
+++ b/packages/lidar_map/src/main.cpp
@@ -3,6 +3,8 @@
 #include "lidar_map/builder.h"
 #include "lidar_map/conversion.h"
 #include "lidar_map/serialization.h"
+#include "tools/progress_bar.h"
+#include "tools/benchmark.h"
 #include "map/map.h"
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
@@ -10,6 +12,8 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <numeric>
 #include <sensor_msgs/msg/laser_scan.hpp>
+
+extern tools::BenchmarkManager benchmarkManager;
 
 using namespace truck::lidar_map;
 using namespace truck::map;
@@ -107,6 +111,8 @@ int main(int argc, char* argv[]) {
     std::string input_mcap_path;
     std::string output_folder_path;
 
+    benchmarkManager.startTimer("Lidar map builder");
+
     {
         po::options_description desc("Executable for constructing 2D LiDAR map");
         desc.add_options()("help,h", "show this help message and exit")(
@@ -168,8 +174,8 @@ int main(int argc, char* argv[]) {
         const auto clouds_tf = builder.transformClouds(poses_optimized, clouds);
 
         const auto clouds_tf_filtered = builder.applyGridFilter(clouds_tf, 0.02);
-        const auto lidar_map =
-            builder.mergeCloudsByPointsSimilarity(clouds_tf_filtered, 6, 0.002, 20);
+        const auto lidar_map = builder.mergeCloudsByPointsSimilarity(
+            poses_optimized, clouds_tf_filtered, 6, 0.002, 20);
 
         if (enable_test) {
             const std::string map_path = kPkgPathMap + "/data/" + vector_map_file;
@@ -181,6 +187,10 @@ int main(int argc, char* argv[]) {
             writeToMCAP(output_folder_path, lidar_map, "/map/lidar");
         }
     }
+
+    benchmarkManager.stopTimer();
+
+    benchmarkManager.displayStatistics();
 
     return 0;
 }

--- a/packages/tools/CMakeLists.txt
+++ b/packages/tools/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.8)
+project(tools)
+
+find_package(ament_cmake REQUIRED)
+
+add_library(${PROJECT_NAME} SHARED src/progress_bar.cpp src/benchmark.cpp)
+
+ament_target_dependencies(${PROJECT_NAME})
+
+target_include_directories(
+        ${PROJECT_NAME}
+        PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+        "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+
+ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
+
+install(
+        TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+)
+
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
+
+ament_package()

--- a/packages/tools/include/tools/benchmark.h
+++ b/packages/tools/include/tools/benchmark.h
@@ -1,0 +1,22 @@
+#include <iostream>
+#include <chrono>
+#include <stack>
+#include <vector>
+#include <string>
+
+namespace tools {
+class BenchmarkTimer;
+
+class BenchmarkManager {
+  public:
+    void startTimer(const std::string&);
+
+    void stopTimer();
+
+    void displayStatistics() const;
+
+  private:
+    std::stack<BenchmarkTimer*> timer_stack;
+    std::deque<BenchmarkTimer> timers;
+};
+}  // namespace tools

--- a/packages/tools/include/tools/progress_bar.h
+++ b/packages/tools/include/tools/progress_bar.h
@@ -1,0 +1,43 @@
+#include <string>
+#include <iostream>
+#include <chrono>
+
+struct Output : std::ostream, std::streambuf {
+    Output(bool enabled) : std::ostream(this), m_enabled(enabled) {}
+
+    int overflow(int c) {
+        if (m_enabled) std::cout.put(c);
+        return 0;
+    }
+
+    bool m_enabled;
+};
+
+namespace tools {
+class ProgressBar {
+  public:
+    ProgressBar(uint32_t, std::ostream& = std::cout, const std::string& = "");
+
+    // ProgressBar has to be non-copyable
+    ProgressBar(const ProgressBar& o) = delete;
+    ProgressBar& operator=(const ProgressBar& o) = delete;
+
+    void operator++();
+
+  private:
+    uint32_t count_ = 0;
+    uint32_t max_count_;
+    std::ostream& os_;
+    std::string title_;
+    std::chrono::time_point<
+        std::chrono::steady_clock, std::chrono::duration<long, std::ratio<1, 1000000000>>>
+        start_time_point;
+
+    std::string GetTitleString();
+    std::string GetBarString();
+    std::string GetTimeString();
+    void UpdateVisual();
+
+    float GetProgressFraction();
+};
+}  // namespace tools

--- a/packages/tools/package.xml
+++ b/packages/tools/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>tools</name>
+  <version>0.0.0</version>
+  <description>tools</description>
+  <maintainer email="simagin.mail@yandex.ru">Simagi Denis</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/packages/tools/src/benchmark.cpp
+++ b/packages/tools/src/benchmark.cpp
@@ -1,0 +1,74 @@
+#include "tools/benchmark.h"
+
+#include <iostream>
+#include <chrono>
+#include <stack>
+#include <vector>
+#include <string>
+
+tools::BenchmarkManager benchmarkManager;
+
+namespace tools {
+class BenchmarkTimer {
+  public:
+    BenchmarkTimer(const std::string& timerName, int timerLevel) :
+        name(timerName), level(timerLevel), start_time(std::chrono::steady_clock::now()) {}
+
+    void stop() {
+        end_time = std::chrono::steady_clock::now();
+        std::chrono::duration<double> elapsed = end_time - start_time;
+        elapsed_time = elapsed.count();
+    }
+
+    void display(bool isLast) const {
+        for (int i = 0; i < level - 1; ++i) {
+            std::cout << "│   ";
+        }
+        if (level > 0) {
+            std::cout << (isLast ? "└── " : "├── ");
+        }
+        uint32_t hours = static_cast<uint32_t>(elapsed_time) / 3600;
+        uint32_t minutes = static_cast<uint32_t>(elapsed_time) / 60;
+        uint32_t seconds = static_cast<uint32_t>(elapsed_time) % 60;
+
+        std::cout << name << ": ";
+        if (hours) {
+            std::cout << hours << "h " << minutes << "m " << seconds << "s" << std::endl;
+        } else if (minutes) {
+            std::cout << minutes << "m " << seconds << "s" << std::endl;
+        } else {
+            std::cout << seconds << "s" << std::endl;
+        }
+    }
+
+    std::string name;
+    int level;
+    std::chrono::steady_clock::time_point start_time;
+    std::chrono::steady_clock::time_point end_time;
+    float elapsed_time;
+};
+
+void BenchmarkManager::startTimer(const std::string& timerName) {
+    int level = timer_stack.size();
+    timers.push_back(BenchmarkTimer(timerName, level));
+    timer_stack.push(&timers.back());
+}
+
+void BenchmarkManager::stopTimer() {
+    if (!timer_stack.empty()) {
+        timer_stack.top()->stop();
+        timer_stack.pop();
+    } else {
+        std::cerr << "No active timers to stop!" << std::endl;
+        throw;
+    }
+}
+
+void BenchmarkManager::displayStatistics() const {
+    std::cout << "\nBENCHMARK STATS:\n";
+    for (size_t i = 0; i < timers.size(); ++i) {
+        bool isLast = (i == timers.size() - 1 || timers[i].level > timers[i + 1].level);
+        timers[i].display(isLast);
+    }
+}
+}  // namespace tools

--- a/packages/tools/src/progress_bar.cpp
+++ b/packages/tools/src/progress_bar.cpp
@@ -1,0 +1,88 @@
+#include "tools/progress_bar.h"
+
+#include <stdint.h>
+#include <iomanip>
+#include <vector>
+
+namespace tools {
+
+void ClearLines(std::ostream& os, size_t n) {
+    for (size_t i = 0; i < n; ++i) {
+        os << "\033[F\033[2K";
+    }
+}
+
+const int PROGRESS_BAR_LENGTH = 50;
+const std::array<std::string, 9> LOADING_CHARS = {"", "▏", "▎", "▍", "▌", "▋", "▊", "▉", "█"};
+
+std::string Repeat(const std::string& s, int n) {
+    std::ostringstream ss;
+    for (int i = 0; i < n; i++) {
+        ss << s;
+    }
+    return ss.str();
+}
+
+std::string GetTimerString(uint32_t hours, uint32_t minutes, uint32_t seconds) {
+    std::stringstream ss;
+    if (hours != 0) {
+        ss << std::setw(2) << std::setfill('0') << hours << ":";
+    }
+    ss << std::setw(2) << std::setfill('0') << minutes << ":";
+    ss << std::setw(2) << std::setfill('0') << seconds;
+    return ss.str();
+}
+
+ProgressBar::ProgressBar(uint32_t max_count, std::ostream& os, const std::string& title) :
+    max_count_(max_count), os_(os), title_(title) {
+    start_time_point = std::chrono::steady_clock::now();
+}
+
+std::string ProgressBar::GetTitleString() {
+    std::ostringstream ss;
+    ss << title_ << ": " << count_ << " / " << max_count_;
+    return ss.str();
+}
+
+std::string ProgressBar::GetTimeString() {
+    auto now = std::chrono::steady_clock::now();
+    auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - start_time_point).count();
+    uint32_t hours = elapsed / 3600;
+    uint32_t minutes = elapsed / 60;
+    uint32_t seconds = elapsed % 60;
+
+    uint64_t elapsed_left = count_ != 0 ? elapsed / GetProgressFraction() - elapsed : 0;
+    uint32_t hours_left = elapsed_left / 3600;
+    uint32_t minutes_left = elapsed_left / 60;
+    uint32_t seconds_left = elapsed_left % 60;
+
+    std::string elapsed_timer = GetTimerString(hours, minutes, seconds);
+    std::string left_timer = GetTimerString(hours_left, minutes_left, seconds_left);
+
+    return "[elapsed: " + elapsed_timer + " left: " + left_timer + "]";
+}
+
+std::string ProgressBar::GetBarString() {
+    float fraction = GetProgressFraction();
+    std::ostringstream ss;
+    ss << ' ' << std::setw(3) << static_cast<int>(fraction * 100) << "."
+       << static_cast<int>(fraction * 1000) % 10 << std::right << "% ";
+    uint32_t whole_size = static_cast<int>(fraction * PROGRESS_BAR_LENGTH);
+    uint32_t remaining = static_cast<int>((fraction * PROGRESS_BAR_LENGTH - whole_size) * 8);
+    ss << "[" << Repeat(LOADING_CHARS.back(), whole_size) << LOADING_CHARS[remaining]
+       << std::string(PROGRESS_BAR_LENGTH - whole_size - (remaining != 0), ' ') << "]";
+    return ss.str();
+}
+
+void ProgressBar::operator++() {
+    ++count_;
+    UpdateVisual();
+}
+
+void ProgressBar::UpdateVisual() {
+    ClearLines(os_, 2);
+    os_ << GetTitleString() << "\n" << GetBarString() << " " << GetTimeString() << std::endl;
+}
+
+float ProgressBar::GetProgressFraction() { return static_cast<float>(count_) / max_count_; }
+}  // namespace tools


### PR DESCRIPTION
1) Added progress bar to track status of cloud merging
https://github.com/user-attachments/assets/241ba53c-1dfb-46f9-9478-193024615dfa

2) Added timing stats to know timings for each tool's part. It has to be useful for tool optimisation in near future.
<img width="403" alt="image" src="https://github.com/user-attachments/assets/c415999c-7e3a-4597-9b76-517c56260472">
(word benchmark might be not good for this tool, but I haven't come with nothing better)

3) Fixed bug in function filterByPosesProximity. It used RTree to thin out points, but it has primarily two cons: firstly, loop closure it's might be better to have two very close to each other points, secondly if you take a ride with car on the same route, thinking that it will increase quality of resulting map, the second lap will be fully removed by this filter, because we will remember each point on the first lap, and will not include points from the second lap as very close points. So I removed RTree and made back old filtration that looked at only two close by time points.

4) Fixed little bug with points filtration inside mergeCloudsByPointsSimilarity, on last iteration of most nested loop with had no chance to add selected point to the answer.

5) Added RTree to selection of poses, which clouds we use in mergeCloudsByPointsSimilarity. In previous version we just were selecting just nearby 20 poses and pick their clouds. Now we build RTree of poses and select no more than N poses not farther than M by distance.